### PR TITLE
Remove job status restrictions and improve UI validation

### DIFF
--- a/internal/job/handlers.go
+++ b/internal/job/handlers.go
@@ -133,7 +133,6 @@ func (h *JobHandler) renderError(c *gin.Context, err error) {
 		errors.Is(err, models.ErrStatusRequired) ||
 		errors.Is(err, models.ErrJobTitleRequired) ||
 		errors.Is(err, models.ErrCompanyNameRequired) ||
-		errors.Is(err, models.ErrInvalidStatusTransition) ||
 		errors.Is(err, models.ErrJobDescriptionRequired) ||
 		errors.Is(err, models.ErrCompanyRequired) ||
 		errors.Is(err, models.ErrInvalidURLFormat) ||
@@ -163,8 +162,7 @@ func (h *JobHandler) renderDashboardError(c *gin.Context, err error) {
 
 	// Determine appropriate status code based on error type
 	if errors.Is(err, models.ErrInvalidJobStatus) ||
-		errors.Is(err, models.ErrStatusRequired) ||
-		errors.Is(err, models.ErrInvalidStatusTransition) {
+		errors.Is(err, models.ErrStatusRequired) {
 		statusCode = http.StatusBadRequest
 	}
 

--- a/internal/job/models/job_model.go
+++ b/internal/job/models/job_model.go
@@ -59,35 +59,6 @@ func (j JobStatus) String() string {
 	}
 }
 
-// IsValidTransition checks if a change from current status to new status is valid.
-// Job status should only move forward in the application process, or to terminal states.
-func IsValidTransition(currentStatus, newStatus JobStatus) bool {
-	if currentStatus == newStatus {
-		return true
-	}
-
-	// Terminal states can't transition except to themselves (handled above)
-	if currentStatus == REJECTED || currentStatus == NOT_INTERESTED {
-		return false
-	}
-
-	// Special case: OFFER_RECEIVED can transition to REJECTED
-	if currentStatus == OFFER_RECEIVED && newStatus == REJECTED {
-		return true
-	}
-
-	if newStatus > currentStatus {
-		return true
-	}
-
-	// Special case: Any state can transition to NOT_INTERESTED
-	if newStatus == NOT_INTERESTED {
-		return true
-	}
-
-	return false
-}
-
 // JobType represents the type of job (e.g., full-time, part-time, etc.).
 type JobType int
 

--- a/internal/job/models/job_model_test.go
+++ b/internal/job/models/job_model_test.go
@@ -210,27 +210,3 @@ func TestJob_Validate(t *testing.T) {
 		})
 	}
 }
-
-func TestIsValidTransition(t *testing.T) {
-	tests := []struct {
-		name    string
-		current JobStatus
-		new     JobStatus
-		want    bool
-	}{
-		{"Same status", INTERESTED, INTERESTED, true},
-		{"Forward progression", INTERESTED, APPLIED, true},
-		{"Multiple forward steps", INTERVIEWING, OFFER_RECEIVED, true},
-		{"Backward progression", APPLIED, INTERESTED, false},
-		{"Terminal state cannot transition", REJECTED, APPLIED, false},
-		{"Offer can be rejected", OFFER_RECEIVED, REJECTED, true},
-		{"Any state to not interested", APPLIED, NOT_INTERESTED, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := IsValidTransition(tt.current, tt.new)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}

--- a/internal/job/services.go
+++ b/internal/job/services.go
@@ -311,29 +311,9 @@ func (s *JobService) UpdateJob(ctx context.Context, job *models.Job) error {
 		return err
 	}
 
-	currentJob, err := s.jobRepo.GetByID(ctx, job.ID)
-	if err != nil {
-		s.log.Error().
-			Int("job_id", job.ID).
-			Err(err).
-			Msg("Failed to get current job state")
-		return err
-	}
-
-	if currentJob.Status != job.Status {
-		if !models.IsValidTransition(currentJob.Status, job.Status) {
-			s.log.Error().
-				Int("job_id", job.ID).
-				Str("current_status", currentJob.Status.String()).
-				Str("new_status", job.Status.String()).
-				Msg("Invalid job status transition")
-			return models.ErrInvalidStatusTransition
-		}
-	}
-
 	job.UpdatedAt = time.Now().UTC()
 
-	err = s.jobRepo.Update(ctx, job)
+	err := s.jobRepo.Update(ctx, job)
 	if err != nil {
 		s.log.Error().
 			Int("job_id", job.ID).

--- a/internal/job/services_test.go
+++ b/internal/job/services_test.go
@@ -299,7 +299,6 @@ func TestJobService(t *testing.T) {
 
 	t.Run("should update job successfully", func(t *testing.T) {
 		mockRepo := new(MockJobRepository)
-		mockRepo.On("GetByID", ctx, job.ID).Return(job, nil)
 		mockRepo.On("Update", ctx, mock.AnythingOfType("*models.Job")).Return(nil)
 
 		service := NewJobService(mockRepo, nil, nil, cfg)

--- a/internal/settings/services/validation.go
+++ b/internal/settings/services/validation.go
@@ -164,10 +164,10 @@ func (v *CentralizedValidator) ValidateWorkExperience(we *models.WorkExperience)
 
 	if we.EndDate != nil {
 		if we.EndDate.After(time.Now()) {
-			return fmt.Errorf("end date cannot be in the future")
+			return fmt.Errorf("End date cannot be in the future")
 		}
 		if we.EndDate.Before(we.StartDate) {
-			return fmt.Errorf("end date must be after start date")
+			return fmt.Errorf("End date must be after start date")
 		}
 	}
 
@@ -211,10 +211,10 @@ func (v *CentralizedValidator) ValidateEducation(ed *models.Education) error {
 
 	if ed.EndDate != nil {
 		if ed.EndDate.After(time.Now()) {
-			return fmt.Errorf("end date cannot be in the future")
+			return fmt.Errorf("End date cannot be in the future")
 		}
 		if ed.EndDate.Before(ed.StartDate) {
-			return fmt.Errorf("end date must be after start date")
+			return fmt.Errorf("End date must be after start date")
 		}
 	}
 
@@ -270,7 +270,7 @@ func (v *CentralizedValidator) ValidateCertification(cert *models.Certification)
 
 	if cert.ExpiryDate != nil {
 		if cert.ExpiryDate.Before(cert.IssueDate) {
-			return fmt.Errorf("expiry date must be after issue date")
+			return fmt.Errorf("Expiry date must be after issue date")
 		}
 	}
 

--- a/templates/partials/cover_letter_generator.html
+++ b/templates/partials/cover_letter_generator.html
@@ -24,10 +24,10 @@
           </button>
         </div>
       </div>
-      
+
       <!-- Mobile-optimized editable cover letter -->
       <div id="cover-letter-content" class="bg-white text-gray-800 p-4 md:p-6 rounded-md whitespace-pre-wrap text-sm md:text-base leading-relaxed min-h-[300px] md:min-h-[400px]">{{.CoverLetter.Content}}</div>
-      
+
       <!-- Mobile editing controls -->
       <div id="mobile-edit-controls" class="mt-4 md:hidden">
         <button class="w-full py-3 px-4 bg-primary hover:bg-primary-dark text-white rounded-md font-medium mb-3"
@@ -98,7 +98,7 @@ function downloadCoverLetter() {
   } else {
     generatePDF();
   }
-  
+
   function generatePDF() {
     const element = document.getElementById('cover-letter-content');
     const opt = {
@@ -114,35 +114,45 @@ function downloadCoverLetter() {
 
 function editCoverLetter() {
   const content = document.getElementById('cover-letter-content');
+  const parent = content.parentElement;
+
+  // Check if already in edit mode
+  if (content.contentEditable === 'true') {
+    return;
+  }
+
   content.contentEditable = true;
   content.focus();
   content.style.border = '2px solid #3b82f6';
   
-  const saveBtn = document.createElement('button');
-  saveBtn.innerText = 'Save';
-  saveBtn.className = 'mt-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white rounded-md text-sm transition-colors';
-  saveBtn.onclick = function() {
-    content.contentEditable = false;
-    content.style.border = 'none';
-    this.remove();
-  };
-  content.parentElement.appendChild(saveBtn);
+  let saveBtn = parent.querySelector('.cover-letter-save-btn');
+  if (!saveBtn) {
+    saveBtn = document.createElement('button');
+    saveBtn.innerText = 'Save';
+    saveBtn.className = 'cover-letter-save-btn mt-2 px-4 py-2 bg-primary hover:bg-primary-dark text-white rounded-md text-sm transition-colors';
+    saveBtn.onclick = function() {
+      content.contentEditable = false;
+      content.style.border = 'none';
+      this.remove();
+    };
+    parent.appendChild(saveBtn);
+  }
 }
 
 // Mobile-specific editing functions
 function enableMobileEdit() {
   const content = document.getElementById('cover-letter-content');
   const editButtons = document.getElementById('mobile-edit-buttons');
-  
+
   content.contentEditable = true;
   content.style.border = '2px solid #3b82f6';
   content.style.minHeight = '400px';
   content.focus();
-  
+
   // Show save/cancel buttons
   editButtons.classList.remove('hidden');
   editButtons.classList.add('flex');
-  
+
   // Hide edit button
   editButtons.previousElementSibling.style.display = 'none';
 }
@@ -150,15 +160,15 @@ function enableMobileEdit() {
 function saveMobileEdit() {
   const content = document.getElementById('cover-letter-content');
   const editButtons = document.getElementById('mobile-edit-buttons');
-  
+
   content.contentEditable = false;
   content.style.border = 'none';
   content.style.minHeight = '300px';
-  
+
   // Hide save/cancel buttons
   editButtons.classList.add('hidden');
   editButtons.classList.remove('flex');
-  
+
   // Show edit button
   editButtons.previousElementSibling.style.display = 'block';
 }
@@ -166,18 +176,18 @@ function saveMobileEdit() {
 function cancelMobileEdit() {
   const content = document.getElementById('cover-letter-content');
   const editButtons = document.getElementById('mobile-edit-buttons');
-  
+
   content.contentEditable = false;
   content.style.border = 'none';
   content.style.minHeight = '300px';
-  
+
   // Reset content (you might want to store original content first)
   location.reload(); // Simple approach - reload to get original content
-  
+
   // Hide save/cancel buttons
   editButtons.classList.add('hidden');
   editButtons.classList.remove('flex');
-  
+
   // Show edit button
   editButtons.previousElementSibling.style.display = 'block';
 }

--- a/templates/partials/error_alert.html
+++ b/templates/partials/error_alert.html
@@ -1,0 +1,12 @@
+{{define "error_alert"}}
+{{if .error}}
+<div class="text-center text-sm block mb-4 p-4 rounded-md bg-red-900 bg-opacity-50 border border-red-700 text-red-200">
+  <div class="flex items-center justify-center">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+    <span class="leading-5">{{.error}}</span>
+  </div>
+</div>
+{{end}}
+{{end}}

--- a/templates/settings/certification_add.html
+++ b/templates/settings/certification_add.html
@@ -42,16 +42,7 @@
   <!-- Certification Form -->
   <div>
     <!-- Error Alert -->
-    {{if .error}}
-    <div class="text-center text-sm block mb-4 p-4 rounded-md bg-red-900 bg-opacity-50 border border-red-700 text-red-200">
-      <div class="flex items-center justify-center">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-        <span class="leading-5">{{.error}}</span>
-      </div>
-    </div>
-    {{end}}
+    {{template "error_alert" .}}
     
     <form action="/settings/profile/certification" method="post" class="space-y-6">
       <div>
@@ -69,15 +60,16 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label for="issue_date" class="block text-sm font-medium text-gray-300 mb-2">Issue Date *</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY (e.g., 06/2022)</p>
           <input type="month" id="issue_date" name="issue_date" required
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
 
         <div>
           <label for="expiry_date" class="block text-sm font-medium text-gray-300 mb-2">Expiry Date</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY - Leave blank if no expiration</p>
           <input type="month" id="expiry_date" name="expiry_date"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
-          <p class="mt-1 text-xs text-gray-400">Leave blank if no expiration</p>
         </div>
       </div>
 

--- a/templates/settings/certification_add.html
+++ b/templates/settings/certification_add.html
@@ -35,22 +35,34 @@
 
   <!-- Page Header -->
   <div class="mb-8">
-    <h2 class="text-2xl font-bold text-white mb-2">Add</h2>
+    <h2 class="text-2xl font-bold text-white mb-2">Add Certification</h2>
     <p class="text-gray-400">Add professional certifications to your profile. This information will be visible to potential employers.</p>
   </div>
 
   <!-- Certification Form -->
   <div>
+    <!-- Error Alert -->
+    {{if .error}}
+    <div class="text-center text-sm block mb-4 p-4 rounded-md bg-red-900 bg-opacity-50 border border-red-700 text-red-200">
+      <div class="flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span class="leading-5">{{.error}}</span>
+      </div>
+    </div>
+    {{end}}
+    
     <form action="/settings/profile/certification" method="post" class="space-y-6">
       <div>
         <label for="name" class="block text-sm font-medium text-gray-300 mb-2">Certification Name *</label>
-        <input type="text" id="name" name="name" required
+        <input type="text" id="name" name="name" required value="{{if .certification}}{{.certification.Name}}{{end}}"
                class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
       </div>
 
       <div>
         <label for="issuing_org" class="block text-sm font-medium text-gray-300 mb-2">Issuing Organization *</label>
-        <input type="text" id="issuing_org" name="issuing_org" required
+        <input type="text" id="issuing_org" name="issuing_org" required value="{{if .certification}}{{.certification.IssuingOrg}}{{end}}"
                class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
       </div>
 
@@ -71,13 +83,13 @@
 
       <div>
         <label for="credential_id" class="block text-sm font-medium text-gray-300 mb-2">Credential ID</label>
-        <input type="text" id="credential_id" name="credential_id"
+        <input type="text" id="credential_id" name="credential_id" value="{{if .certification}}{{.certification.CredentialID}}{{end}}"
                class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
       </div>
 
       <div>
         <label for="credential_url" class="block text-sm font-medium text-gray-300 mb-2">Credential URL</label>
-        <input type="url" id="credential_url" name="credential_url"
+        <input type="url" id="credential_url" name="credential_url" value="{{if .certification}}{{.certification.CredentialURL}}{{end}}"
                class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                placeholder="https://example.com/credential">
       </div>

--- a/templates/settings/certification_edit.html
+++ b/templates/settings/certification_edit.html
@@ -61,15 +61,16 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label for="issue_date" class="block text-sm font-medium text-gray-300 mb-2">Issue Date *</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY (e.g., 06/2022)</p>
           <input type="month" id="issue_date" name="issue_date" value="{{.certification.IssueDate.Format "2006-01"}}" required
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
 
         <div>
           <label for="expiry_date" class="block text-sm font-medium text-gray-300 mb-2">Expiry Date</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY - Leave blank if no expiration</p>
           <input type="month" id="expiry_date" name="expiry_date" value="{{if .certification.ExpiryDate}}{{.certification.ExpiryDate.Format "2006-01"}}{{end}}"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
-          <p class="mt-1 text-xs text-gray-400">Leave blank if no expiration</p>
         </div>
       </div>
 

--- a/templates/settings/education_add.html
+++ b/templates/settings/education_add.html
@@ -42,16 +42,7 @@
   <!-- Education Form -->
   <div>
     <!-- Error Alert -->
-    {{if .error}}
-    <div class="text-center text-sm block mb-4 p-4 rounded-md bg-red-900 bg-opacity-50 border border-red-700 text-red-200">
-      <div class="flex items-center justify-center">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-        <span class="leading-5">{{.error}}</span>
-      </div>
-    </div>
-    {{end}}
+    {{template "error_alert" .}}
     
     <form action="/settings/profile/education" method="post" class="space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -77,15 +68,16 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label for="start_date" class="block text-sm font-medium text-gray-300 mb-2">Start Date *</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY (e.g., 09/2019)</p>
           <input type="month" id="start_date" name="start_date" required
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
 
         <div>
           <label for="end_date" class="block text-sm font-medium text-gray-300 mb-2">End Date</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY - Leave blank if still studying</p>
           <input type="month" id="end_date" name="end_date"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
-          <p class="mt-1 text-xs text-gray-400">Leave blank if still studying</p>
         </div>
       </div>
 

--- a/templates/settings/education_add.html
+++ b/templates/settings/education_add.html
@@ -35,30 +35,42 @@
 
   <!-- Page Header -->
   <div class="mb-8">
-    <h2 class="text-2xl font-bold text-white mb-2">Add</h2>
+    <h2 class="text-2xl font-bold text-white mb-2">Add Education</h2>
     <p class="text-gray-400">Add educational qualifications to your profile. This information will be visible to potential employers.</p>
   </div>
 
   <!-- Education Form -->
   <div>
+    <!-- Error Alert -->
+    {{if .error}}
+    <div class="text-center text-sm block mb-4 p-4 rounded-md bg-red-900 bg-opacity-50 border border-red-700 text-red-200">
+      <div class="flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span class="leading-5">{{.error}}</span>
+      </div>
+    </div>
+    {{end}}
+    
     <form action="/settings/profile/education" method="post" class="space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label for="institution" class="block text-sm font-medium text-gray-300 mb-2">School/Institution *</label>
-          <input type="text" id="institution" name="institution" required
+          <input type="text" id="institution" name="institution" required value="{{if .education}}{{.education.Institution}}{{end}}"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
 
         <div>
           <label for="degree" class="block text-sm font-medium text-gray-300 mb-2">Degree *</label>
-          <input type="text" id="degree" name="degree" required
+          <input type="text" id="degree" name="degree" required value="{{if .education}}{{.education.Degree}}{{end}}"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
       </div>
 
       <div>
         <label for="field_of_study" class="block text-sm font-medium text-gray-300 mb-2">Field of Study</label>
-        <input type="text" id="field_of_study" name="field_of_study"
+        <input type="text" id="field_of_study" name="field_of_study" value="{{if .education}}{{.education.FieldOfStudy}}{{end}}"
                class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
       </div>
 
@@ -81,7 +93,7 @@
         <label for="description" class="block text-sm font-medium text-gray-300 mb-2">Description</label>
         <textarea id="description" name="description" rows="4"
                   class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
-                  placeholder="Optional: Add any relevant coursework, achievements, or other details"></textarea>
+                  placeholder="Optional: Add any relevant coursework, achievements, or other details">{{if .education}}{{.education.Description}}{{end}}</textarea>
       </div>
 
       <!-- Form Actions -->

--- a/templates/settings/education_edit.html
+++ b/templates/settings/education_edit.html
@@ -69,15 +69,16 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label for="start_date" class="block text-sm font-medium text-gray-300 mb-2">Start Date *</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY (e.g., 09/2019)</p>
           <input type="month" id="start_date" name="start_date" value="{{.education.StartDate.Format "2006-01"}}" required
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
 
         <div>
           <label for="end_date" class="block text-sm font-medium text-gray-300 mb-2">End Date</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY - Leave blank if still studying</p>
           <input type="month" id="end_date" name="end_date" value="{{if .education.EndDate}}{{.education.EndDate.Format "2006-01"}}{{end}}"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
-          <p class="mt-1 text-xs text-gray-400">Leave blank if still studying</p>
         </div>
       </div>
 

--- a/templates/settings/experience_add.html
+++ b/templates/settings/experience_add.html
@@ -41,24 +41,36 @@
 
   <!-- Experience Form -->
   <div>
+    <!-- Error Alert -->
+    {{if .error}}
+    <div class="text-center text-sm block mb-4 p-4 rounded-md bg-red-900 bg-opacity-50 border border-red-700 text-red-200">
+      <div class="flex items-center justify-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span class="leading-5">{{.error}}</span>
+      </div>
+    </div>
+    {{end}}
+    
     <form action="/settings/profile/experience" method="post" class="space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label for="title" class="block text-sm font-medium text-gray-300 mb-2">Job Title *</label>
-          <input type="text" id="title" name="title" required
+          <input type="text" id="title" name="title" required value="{{if .experience}}{{.experience.Title}}{{end}}"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
 
         <div>
           <label for="company" class="block text-sm font-medium text-gray-300 mb-2">Company *</label>
-          <input type="text" id="company" name="company" required
+          <input type="text" id="company" name="company" required value="{{if .experience}}{{.experience.Company}}{{end}}"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
       </div>
 
       <div>
         <label for="location" class="block text-sm font-medium text-gray-300 mb-2">Location</label>
-        <input type="text" id="location" name="location"
+        <input type="text" id="location" name="location" value="{{if .experience}}{{.experience.Location}}{{end}}"
                class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
       </div>
 
@@ -90,7 +102,7 @@
         <p class="text-xs text-gray-400 mb-2">Add your key responsibilities and achievements one per line. Use bullet points (•) for better formatting.</p>
         <textarea id="description" name="description" rows="6" 
                   class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary" 
-                  placeholder="• Managed team of 5 developers&#10;• Increased revenue by 20%&#10;• Implemented CI/CD pipeline"></textarea>
+                  placeholder="• Managed team of 5 developers&#10;• Increased revenue by 20%&#10;• Implemented CI/CD pipeline">{{if .experience}}{{.experience.Description}}{{end}}</textarea>
       </div>
 
       <!-- Form Actions -->

--- a/templates/settings/experience_add.html
+++ b/templates/settings/experience_add.html
@@ -42,16 +42,7 @@
   <!-- Experience Form -->
   <div>
     <!-- Error Alert -->
-    {{if .error}}
-    <div class="text-center text-sm block mb-4 p-4 rounded-md bg-red-900 bg-opacity-50 border border-red-700 text-red-200">
-      <div class="flex items-center justify-center">
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-2 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-        </svg>
-        <span class="leading-5">{{.error}}</span>
-      </div>
-    </div>
-    {{end}}
+    {{template "error_alert" .}}
     
     <form action="/settings/profile/experience" method="post" class="space-y-6">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -77,12 +68,14 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label for="start_date" class="block text-sm font-medium text-gray-300 mb-2">Start Date *</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY (e.g., 01/2023)</p>
           <input type="month" id="start_date" name="start_date" required
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
 
         <div>
           <label for="end_date" class="block text-sm font-medium text-gray-300 mb-2">End Date</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY (leave blank if current)</p>
           <input type="month" id="end_date" name="end_date"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>

--- a/templates/settings/experience_edit.html
+++ b/templates/settings/experience_edit.html
@@ -69,12 +69,14 @@
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
           <label for="start_date" class="block text-sm font-medium text-gray-300 mb-2">Start Date *</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY (e.g., 01/2023)</p>
           <input type="month" id="start_date" name="start_date" value="{{.experience.StartDate.Format "2006-01"}}" required
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary">
         </div>
 
         <div>
           <label for="end_date" class="block text-sm font-medium text-gray-300 mb-2">End Date</label>
+          <p class="text-xs text-gray-400 mb-2">Format: MM/YYYY (leave blank if current)</p>
           <input type="month" id="end_date" name="end_date" value="{{if .experience.EndDate}}{{.experience.EndDate.Format "2006-01"}}{{end}}"
                  class="w-full px-4 py-2 rounded-lg bg-slate-700 bg-opacity-50 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary"
                  {{if .experience.Current}}disabled{{end}}>


### PR DESCRIPTION
## 🚀 What's this about?

This PR removes job status transition restrictions, allowing users to freely change job statuses without validation constraints. Also, it fixes a UI bug where multiple save buttons were created when editing cover letters and improves error handling in the settings module.

## 💡 Why this matters

1. **Enhanced User Flexibility**: Users expressed frustration with rigid job status transitions. They need the ability to move jobs between any status freely to match their real-world workflow.

2. **Better UX**: The cover letter editor was creating duplicate save buttons on multiple clicks, causing confusion. This fix ensures only one save button exists at a time.

3. **Improved Validation**: Enhanced error handling in the settings module provides clearer feedback when users have incomplete profiles.

## ✅ How was this tested?

- [x] Tested locally
- [x] All tests pass
- [x] Manually verified the change works as expected
