### PR TITLE
Fix authentication loop on HTTP deployments

### DIFF
--- a/.github/workflows/docker-build-cloud.yml
+++ b/.github/workflows/docker-build-cloud.yml
@@ -77,3 +77,4 @@ jobs:
         cache-to: type=gha,mode=max
         build-args: |
           CLOUD_MODE=true
+          COOKIE_SECURE=true

--- a/.github/workflows/docker-build-cloud.yml
+++ b/.github/workflows/docker-build-cloud.yml
@@ -77,4 +77,3 @@ jobs:
         cache-to: type=gha,mode=max
         build-args: |
           CLOUD_MODE=true
-          COOKIE_SECURE=true

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+set -e
+
+generate_token() {
+    head -c 32 /dev/urandom | base64 | tr -d '\n'
+}
+
+# Generate TOKEN_SECRET if not provided
+if [ -z "$TOKEN_SECRET" ] || [ "$TOKEN_SECRET" = "default-secret-key" ]; then
+    if [ "$CLOUD_MODE" = "false" ]; then
+        echo "=================================================="
+        echo "WARNING: No TOKEN_SECRET provided."
+        echo "Generating a random secret..."
+        echo ""
+        echo "For production use, please set a persistent"
+        echo "TOKEN_SECRET environment variable."
+        echo "=================================================="
+        export TOKEN_SECRET=$(generate_token)
+    else
+        echo "ERROR: TOKEN_SECRET must be set for cloud deployments"
+        exit 1
+    fi
+fi
+
+# Validate required settings for cloud mode
+if [ "$CLOUD_MODE" = "true" ]; then
+    if [ -z "$GOOGLE_CLIENT_ID" ] || [ -z "$GOOGLE_CLIENT_SECRET" ]; then
+        echo "ERROR: Google OAuth credentials required for cloud mode"
+        exit 1
+    fi
+    # Ensure HTTPS cookies for cloud mode
+    export COOKIE_SECURE="true"
+fi
+
+echo "Starting Vega AI..."
+echo "Mode: $([ "$CLOUD_MODE" = "true" ] && echo "Cloud" || echo "Self-hosted")"
+
+# Create data directory if it doesn't exist
+mkdir -p /app/data
+
+exec "$@"

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -19,6 +19,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build \
 FROM alpine:3.20
 
 ARG CLOUD_MODE=false
+ARG COOKIE_SECURE=${CLOUD_MODE}
 
 RUN apk --no-cache add ca-certificates tzdata wget && \
     addgroup -g 1001 -S appgroup && \
@@ -27,18 +28,22 @@ RUN apk --no-cache add ca-certificates tzdata wget && \
 WORKDIR /app
 
 ENV CLOUD_MODE=${CLOUD_MODE}
+ENV COOKIE_SECURE=${COOKIE_SECURE}
 
 COPY --from=builder /build/vega .
 
 COPY --from=builder /build/templates ./templates
 COPY --from=builder /build/migrations ./migrations
 COPY --from=builder /build/static ./static
+COPY ./docker/entrypoint.sh /app/entrypoint.sh
 
 RUN mkdir -p /app/data && \
+    chmod +x /app/entrypoint.sh && \
     chown -R appuser:appgroup /app
 
 USER appuser
 
 EXPOSE 8765
 
+ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["./vega"]

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -19,7 +19,6 @@ RUN CGO_ENABLED=1 GOOS=linux go build \
 FROM alpine:3.20
 
 ARG CLOUD_MODE=false
-ARG COOKIE_SECURE=${CLOUD_MODE}
 
 RUN apk --no-cache add ca-certificates tzdata wget && \
     addgroup -g 1001 -S appgroup && \
@@ -28,7 +27,6 @@ RUN apk --no-cache add ca-certificates tzdata wget && \
 WORKDIR /app
 
 ENV CLOUD_MODE=${CLOUD_MODE}
-ENV COOKIE_SECURE=${COOKIE_SECURE}
 
 COPY --from=builder /build/vega .
 

--- a/internal/common/auth/helpers.go
+++ b/internal/common/auth/helpers.go
@@ -1,0 +1,34 @@
+package auth
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// GetUserID safely retrieves the user ID from the Gin context.
+// It returns the user ID and a boolean indicating whether it was found.
+// This helper ensures consistent error handling across the application.
+func GetUserID(c *gin.Context) (int, bool) {
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		return 0, false
+	}
+
+	userID, ok := userIDValue.(int)
+	if !ok {
+		return 0, false
+	}
+
+	return userID, true
+}
+
+// MustGetUserID retrieves the user ID from the Gin context.
+// It panics if the user ID is not found or is not an integer.
+// This should only be used in handlers that are guaranteed to run
+// after authentication middleware.
+func MustGetUserID(c *gin.Context) int {
+	userID, ok := GetUserID(c)
+	if !ok {
+		panic("userID not found in context or invalid type")
+	}
+	return userID
+}

--- a/internal/job/repository/job_repository.go
+++ b/internal/job/repository/job_repository.go
@@ -71,7 +71,7 @@ func (r *SQLiteJobRepository) scanJob(s scanner) (*models.Job, error) {
 		&j.ID, &j.Title, &j.Description, &location, &jobType,
 		&sourceURL, &skillsJSON,
 		&applicationURL, &company.ID, &status, &matchScore,
-		&notes, &j.CreatedAt, &j.UpdatedAt,
+		&notes, &j.CreatedAt, &j.UpdatedAt, &j.UserID,
 		&company.ID, &company.Name, &company.CreatedAt, &company.UpdatedAt,
 	)
 	if err != nil {
@@ -140,7 +140,7 @@ func (r *SQLiteJobRepository) GetBySourceURL(ctx context.Context, userID int, so
 			j.id, j.title, j.description, j.location, j.job_type,
 			j.source_url, j.required_skills,
 			j.application_url, j.company_id, j.status, j.match_score,
-			j.notes, j.created_at, j.updated_at,
+			j.notes, j.created_at, j.updated_at, j.user_id,
 			c.id, c.name, c.created_at, c.updated_at
 		FROM jobs j
 		JOIN companies c ON j.company_id = c.id
@@ -249,7 +249,7 @@ func (r *SQLiteJobRepository) GetByID(ctx context.Context, userID int, id int) (
 			j.id, j.title, j.description, j.location, j.job_type,
 			j.source_url, j.required_skills,
 			j.application_url, j.company_id, j.status, j.match_score,
-			j.notes, j.created_at, j.updated_at,
+			j.notes, j.created_at, j.updated_at, j.user_id,
 			c.id, c.name, c.created_at, c.updated_at
 		FROM jobs j
 		JOIN companies c ON j.company_id = c.id
@@ -282,7 +282,7 @@ func (r *SQLiteJobRepository) GetAll(ctx context.Context, userID int, filter mod
 			j.id, j.title, j.description, j.location, j.job_type,
 			j.source_url, j.required_skills,
 			j.application_url, j.company_id, j.status, j.match_score,
-			j.notes, j.created_at, j.updated_at,
+			j.notes, j.created_at, j.updated_at, j.user_id,
 			c.id, c.name, c.created_at, c.updated_at
 		FROM jobs j
 		JOIN companies c ON j.company_id = c.id

--- a/internal/job/repository/job_repository_test.go
+++ b/internal/job/repository/job_repository_test.go
@@ -200,13 +200,13 @@ func TestSQLiteJobRepository_GetByID(t *testing.T) {
 			"j.id", "j.title", "j.description", "j.location", "j.job_type",
 			"j.source_url", "j.required_skills",
 			"j.application_url", "j.company_id", "j.status", "j.match_score",
-			"j.notes", "j.created_at", "j.updated_at",
+			"j.notes", "j.created_at", "j.updated_at", "j.user_id",
 			"c.id", "c.name", "c.created_at", "c.updated_at",
 		}).AddRow(
 			jobID, "Software Engineer", "Build awesome software", "Remote", int(models.FULL_TIME),
 			"https://example.com", `["Go","SQL"]`,
 			"https://apply.example.com", 2, int(models.INTERESTED), 85,
-			"Great company", now.Add(-24*time.Hour), now,
+			"Great company", now.Add(-24*time.Hour), now, testUserID,
 			2, "Acme Corp", now, now,
 		)
 
@@ -305,13 +305,13 @@ func TestSQLiteJobRepository_GetAll(t *testing.T) {
 			"j.id", "j.title", "j.description", "j.location", "j.job_type",
 			"j.source_url", "j.required_skills",
 			"j.application_url", "j.company_id", "j.status", "j.match_score",
-			"j.notes", "j.created_at", "j.updated_at",
+			"j.notes", "j.created_at", "j.updated_at", "j.user_id",
 			"c.id", "c.name", "c.created_at", "c.updated_at",
 		}).AddRow(
 			1, "Software Engineer", "Build awesome software", "Remote", int(models.FULL_TIME),
 			"https://example.com", `["Go","SQL"]`,
 			"https://apply.example.com", companyID, int(models.INTERESTED), 92,
-			"Great company", now.Add(-24*time.Hour), now,
+			"Great company", now.Add(-24*time.Hour), now, testUserID,
 			companyID, "Acme Corp", now, now,
 		)
 
@@ -517,16 +517,16 @@ func TestGetRecentJobsByUserID(t *testing.T) {
 				rows := sqlmock.NewRows([]string{
 					"id", "title", "description", "location", "job_type",
 					"source_url", "skills", "application_url", "company_id",
-					"status", "match_score", "notes", "created_at", "updated_at",
+					"status", "match_score", "notes", "created_at", "updated_at", "user_id",
 					"company_id", "company_name", "company_created_at", "company_updated_at",
 				}).AddRow(
 					1, "Engineer", "Great job", "Remote", int(models.FULL_TIME),
 					"https://example.com", `["Go"]`, "", 1, int(models.APPLIED), 85,
-					"Good fit", now, now, 1, "Test Company", now, now,
+					"Good fit", now, now, testUserID, 1, "Test Company", now, now,
 				).AddRow(
 					2, "Developer", "Another job", "NYC", int(models.PART_TIME),
 					"https://example2.com", `["Python"]`, "", 1, int(models.INTERESTED), 75,
-					"Interesting", now, now, 1, "Test Company", now, now,
+					"Interesting", now, now, testUserID, 1, "Test Company", now, now,
 				)
 
 				mock.ExpectQuery("SELECT.*FROM jobs.*WHERE.*user_id.*ORDER BY.*LIMIT").
@@ -571,7 +571,7 @@ func TestGetRecentJobsByUserID(t *testing.T) {
 				rows := sqlmock.NewRows([]string{
 					"id", "title", "description", "location", "job_type",
 					"source_url", "skills", "application_url", "company_id",
-					"status", "match_score", "notes", "created_at", "updated_at",
+					"status", "match_score", "notes", "created_at", "updated_at", "user_id",
 					"company_id", "company_name", "company_created_at", "company_updated_at",
 				})
 

--- a/internal/settings/base.go
+++ b/internal/settings/base.go
@@ -64,9 +64,14 @@ func NewBaseSettingsHandler(service CRUDService, metadata EntityMetadata) *BaseS
 
 // GetAddPage handles the request to display the add entity page
 func (h *BaseSettingsHandler) GetAddPage(c *gin.Context) {
-	userID, _ := c.Get("userID")
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		h.renderer.Error(c, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+	userID := userIDValue.(int)
 
-	profile, err := h.service.GetProfileSettings(c.Request.Context(), userID.(int))
+	profile, err := h.service.GetProfileSettings(c.Request.Context(), userID)
 	if err != nil {
 		profile = &models.Profile{}
 	}

--- a/internal/settings/handlers.go
+++ b/internal/settings/handlers.go
@@ -132,9 +132,14 @@ func (h *SettingsHandler) formatValidationError(err error) string {
 
 // GetProfileSettingsPage handles the request to display the profile settings page
 func (h *SettingsHandler) GetProfileSettingsPage(c *gin.Context) {
-	userID, _ := c.Get("userID")
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		h.renderer.Error(c, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+	userID := userIDValue.(int)
 
-	profile, err := h.service.GetProfileWithRelated(c.Request.Context(), userID.(int))
+	profile, err := h.service.GetProfileWithRelated(c.Request.Context(), userID)
 
 	if err != nil {
 		h.renderer.HTML(c, http.StatusInternalServerError, "layouts/base.html", gin.H{
@@ -165,7 +170,15 @@ func (h *SettingsHandler) GetProfileSettingsPage(c *gin.Context) {
 
 // HandleCreateProfile handles the creation or update of a user's profile settings
 func (h *SettingsHandler) HandleCreateProfile(c *gin.Context) {
-	userID := c.GetInt("userID")
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		h.renderer.HTML(c, http.StatusUnauthorized, "partials/alerts/alert.html", gin.H{
+			"message": "Unauthorized",
+			"type":    "error",
+		})
+		return
+	}
+	userID := userIDValue.(int)
 
 	firstName := strings.TrimSpace(c.PostForm("first_name"))
 	lastName := strings.TrimSpace(c.PostForm("last_name"))

--- a/internal/settings/interfaces/repository.go
+++ b/internal/settings/interfaces/repository.go
@@ -17,17 +17,17 @@ type SettingsRepository interface {
 	GetWorkExperiences(ctx context.Context, profileID int) ([]models.WorkExperience, error)
 	AddWorkExperience(ctx context.Context, experience *models.WorkExperience) error
 	UpdateWorkExperience(ctx context.Context, experience *models.WorkExperience) (*models.WorkExperience, error)
-	DeleteWorkExperience(ctx context.Context, id int) error
+	DeleteWorkExperience(ctx context.Context, id int, profileID int) error
 	DeleteAllWorkExperience(ctx context.Context, profileID int) error
 
 	GetEducation(ctx context.Context, profileID int) ([]models.Education, error)
 	AddEducation(ctx context.Context, education *models.Education) error
 	UpdateEducation(ctx context.Context, education *models.Education) (*models.Education, error)
-	DeleteEducation(ctx context.Context, id int) error
+	DeleteEducation(ctx context.Context, id int, profileID int) error
 	DeleteAllEducation(ctx context.Context, profileID int) error
 
 	GetCertifications(ctx context.Context, profileID int) ([]models.Certification, error)
 	AddCertification(ctx context.Context, certification *models.Certification) error
 	UpdateCertification(ctx context.Context, certification *models.Certification) (*models.Certification, error)
-	DeleteCertification(ctx context.Context, id int) error
+	DeleteCertification(ctx context.Context, id int, profileID int) error
 }

--- a/internal/settings/models/errors.go
+++ b/internal/settings/models/errors.go
@@ -5,6 +5,9 @@ import (
 )
 
 var (
+	// Authentication errors
+	ErrUnauthorized = commonerrors.New("unauthorized")
+
 	// Model validation errors
 	ErrInvalidSettingsType = commonerrors.New("invalid settings type")
 	ErrFieldRequired       = commonerrors.New("field is required")

--- a/internal/settings/repository/profile.go
+++ b/internal/settings/repository/profile.go
@@ -364,7 +364,7 @@ func (r *ProfileRepository) UpdateWorkExperience(ctx context.Context, experience
 		UPDATE work_experiences
 		SET company = ?, title = ?, location = ?, start_date = ?, end_date = ?,
 		    description = ?, current = ?, updated_at = ?
-		WHERE id = ?`
+		WHERE id = ? AND profile_id = ?`
 
 	endDate := toNullTime(experience.EndDate)
 	now := time.Now().UTC()
@@ -372,7 +372,7 @@ func (r *ProfileRepository) UpdateWorkExperience(ctx context.Context, experience
 	result, err := r.db.ExecContext(ctx, query,
 		experience.Company, experience.Title, experience.Location,
 		experience.StartDate, endDate, experience.Description,
-		experience.Current, now, experience.ID,
+		experience.Current, now, experience.ID, experience.ProfileID,
 	)
 
 	if err != nil {
@@ -393,10 +393,10 @@ func (r *ProfileRepository) UpdateWorkExperience(ctx context.Context, experience
 }
 
 // DeleteWorkExperience deletes a work experience entry by its ID.
-func (r *ProfileRepository) DeleteWorkExperience(ctx context.Context, id int) error {
-	query := "DELETE FROM work_experiences WHERE id = ?"
+func (r *ProfileRepository) DeleteWorkExperience(ctx context.Context, id int, profileID int) error {
+	query := "DELETE FROM work_experiences WHERE id = ? AND profile_id = ?"
 
-	result, err := r.db.ExecContext(ctx, query, id)
+	result, err := r.db.ExecContext(ctx, query, id, profileID)
 	if err != nil {
 		return err
 	}
@@ -492,7 +492,7 @@ func (r *ProfileRepository) UpdateEducation(ctx context.Context, education *mode
 		UPDATE education
 		SET institution = ?, degree = ?, field_of_study = ?, start_date = ?,
 		    end_date = ?, description = ?, updated_at = ?
-		WHERE id = ?`
+		WHERE id = ? AND profile_id = ?`
 
 	var endDate sql.NullTime
 	if education.EndDate != nil {
@@ -504,7 +504,7 @@ func (r *ProfileRepository) UpdateEducation(ctx context.Context, education *mode
 
 	result, err := r.db.ExecContext(ctx, query,
 		education.Institution, education.Degree, education.FieldOfStudy,
-		education.StartDate, endDate, education.Description, now, education.ID,
+		education.StartDate, endDate, education.Description, now, education.ID, education.ProfileID,
 	)
 
 	if err != nil {
@@ -525,10 +525,10 @@ func (r *ProfileRepository) UpdateEducation(ctx context.Context, education *mode
 }
 
 // DeleteEducation deletes an education record by its ID from the database.
-func (r *ProfileRepository) DeleteEducation(ctx context.Context, id int) error {
-	query := "DELETE FROM education WHERE id = ?"
+func (r *ProfileRepository) DeleteEducation(ctx context.Context, id int, profileID int) error {
+	query := "DELETE FROM education WHERE id = ? AND profile_id = ?"
 
-	result, err := r.db.ExecContext(ctx, query, id)
+	result, err := r.db.ExecContext(ctx, query, id, profileID)
 	if err != nil {
 		return err
 	}
@@ -625,7 +625,7 @@ func (r *ProfileRepository) UpdateCertification(ctx context.Context, certificati
 		UPDATE certifications
 		SET name = ?, issuing_org = ?, issue_date = ?, expiry_date = ?,
 		    credential_id = ?, credential_url = ?, updated_at = ?
-		WHERE id = ?`
+		WHERE id = ? AND profile_id = ?`
 
 	var expiryDate sql.NullTime
 	if certification.ExpiryDate != nil {
@@ -638,7 +638,7 @@ func (r *ProfileRepository) UpdateCertification(ctx context.Context, certificati
 	result, err := r.db.ExecContext(ctx, query,
 		certification.Name, certification.IssuingOrg, certification.IssueDate,
 		expiryDate, certification.CredentialID, certification.CredentialURL,
-		now, certification.ID,
+		now, certification.ID, certification.ProfileID,
 	)
 
 	if err != nil {
@@ -659,10 +659,10 @@ func (r *ProfileRepository) UpdateCertification(ctx context.Context, certificati
 }
 
 // DeleteCertification deletes a certification record by its ID from the database.
-func (r *ProfileRepository) DeleteCertification(ctx context.Context, id int) error {
-	query := "DELETE FROM certifications WHERE id = ?"
+func (r *ProfileRepository) DeleteCertification(ctx context.Context, id int, profileID int) error {
+	query := "DELETE FROM certifications WHERE id = ? AND profile_id = ?"
 
-	result, err := r.db.ExecContext(ctx, query, id)
+	result, err := r.db.ExecContext(ctx, query, id, profileID)
 	if err != nil {
 		return err
 	}

--- a/internal/settings/repository/profile_test.go
+++ b/internal/settings/repository/profile_test.go
@@ -181,7 +181,7 @@ func TestWorkExperienceOperations(t *testing.T) {
 		mock.ExpectExec("UPDATE work_experiences SET").
 			WithArgs(
 				exp.Company, exp.Title, exp.Location, exp.StartDate,
-				nil, exp.Description, exp.Current, sqlmock.AnyArg(), exp.ID, // nil for EndDate, AnyArg for updated_at
+				nil, exp.Description, exp.Current, sqlmock.AnyArg(), exp.ID, exp.ProfileID, // nil for EndDate, AnyArg for updated_at
 			).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -193,20 +193,20 @@ func TestWorkExperienceOperations(t *testing.T) {
 
 	t.Run("delete work experience", func(t *testing.T) {
 		mock.ExpectExec("DELETE FROM work_experiences WHERE").
-			WithArgs(10).
+			WithArgs(10, exp.ProfileID).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
-		err := repo.DeleteWorkExperience(ctx, 10)
+		err := repo.DeleteWorkExperience(ctx, 10, exp.ProfileID)
 		require.NoError(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
 	t.Run("delete non-existent work experience", func(t *testing.T) {
 		mock.ExpectExec("DELETE FROM work_experiences WHERE").
-			WithArgs(999).
+			WithArgs(999, exp.ProfileID).
 			WillReturnResult(sqlmock.NewResult(0, 0))
 
-		err := repo.DeleteWorkExperience(ctx, 999)
+		err := repo.DeleteWorkExperience(ctx, 999, exp.ProfileID)
 		assert.Error(t, err)
 		assert.Equal(t, models.ErrWorkExperienceNotFound, err)
 		require.NoError(t, mock.ExpectationsWereMet())
@@ -250,7 +250,7 @@ func TestEducationOperations(t *testing.T) {
 			WithArgs(
 				edu.Institution, edu.Degree, edu.FieldOfStudy,
 				edu.StartDate, sqlmock.AnyArg(), edu.Description,
-				sqlmock.AnyArg(), edu.ID, // updated_at, id
+				sqlmock.AnyArg(), edu.ID, edu.ProfileID, // updated_at, id, profileID
 			).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -262,10 +262,10 @@ func TestEducationOperations(t *testing.T) {
 
 	t.Run("delete education", func(t *testing.T) {
 		mock.ExpectExec("DELETE FROM education WHERE").
-			WithArgs(20).
+			WithArgs(20, edu.ProfileID).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
-		err := repo.DeleteEducation(ctx, 20)
+		err := repo.DeleteEducation(ctx, 20, edu.ProfileID)
 		require.NoError(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
@@ -307,7 +307,7 @@ func TestCertificationOperations(t *testing.T) {
 		mock.ExpectExec("UPDATE certifications SET").
 			WithArgs(
 				cert.Name, cert.IssuingOrg, cert.IssueDate, sqlmock.AnyArg(),
-				cert.CredentialID, cert.CredentialURL, sqlmock.AnyArg(), cert.ID, // updated_at, id
+				cert.CredentialID, cert.CredentialURL, sqlmock.AnyArg(), cert.ID, cert.ProfileID, // updated_at, id, profileID
 			).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
@@ -319,10 +319,10 @@ func TestCertificationOperations(t *testing.T) {
 
 	t.Run("delete certification", func(t *testing.T) {
 		mock.ExpectExec("DELETE FROM certifications WHERE").
-			WithArgs(30).
+			WithArgs(30, cert.ProfileID).
 			WillReturnResult(sqlmock.NewResult(0, 1))
 
-		err := repo.DeleteCertification(ctx, 30)
+		err := repo.DeleteCertification(ctx, 30, cert.ProfileID)
 		require.NoError(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})

--- a/internal/settings/services.go
+++ b/internal/settings/services.go
@@ -187,7 +187,7 @@ func (s *SettingsService) DeleteEntity(ctx *gin.Context, entityID, profileID int
 
 	switch entityType {
 	case "Experience":
-		if err := s.settingsRepo.DeleteWorkExperience(ctx.Request.Context(), entityID); err != nil {
+		if err := s.settingsRepo.DeleteWorkExperience(ctx.Request.Context(), entityID, profileID); err != nil {
 			s.log.Error().Err(err).Int("experience_id", entityID).Msg("Failed to delete work experience")
 			if err == models.ErrWorkExperienceNotFound {
 				return err
@@ -197,7 +197,7 @@ func (s *SettingsService) DeleteEntity(ctx *gin.Context, entityID, profileID int
 		s.log.Info().Int("experience_id", entityID).Int("profile_id", profileID).Msg("Successfully deleted work experience")
 		return nil
 	case "Education":
-		if err := s.settingsRepo.DeleteEducation(ctx.Request.Context(), entityID); err != nil {
+		if err := s.settingsRepo.DeleteEducation(ctx.Request.Context(), entityID, profileID); err != nil {
 			s.log.Error().Err(err).Int("education_id", entityID).Msg("Failed to delete education entry")
 			if err == models.ErrEducationNotFound {
 				return err
@@ -207,7 +207,7 @@ func (s *SettingsService) DeleteEntity(ctx *gin.Context, entityID, profileID int
 		s.log.Info().Int("education_id", entityID).Int("profile_id", profileID).Msg("Successfully deleted education entry")
 		return nil
 	case "Certification":
-		if err := s.settingsRepo.DeleteCertification(ctx.Request.Context(), entityID); err != nil {
+		if err := s.settingsRepo.DeleteCertification(ctx.Request.Context(), entityID, profileID); err != nil {
 			s.log.Error().Err(err).Int("certification_id", entityID).Msg("Failed to delete certification")
 			if err == models.ErrCertificationNotFound {
 				return err

--- a/internal/settings/services_entity_test.go
+++ b/internal/settings/services_entity_test.go
@@ -55,6 +55,7 @@ func TestEntityOperations(t *testing.T) {
 		w := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(w)
 		ctx.Request = httptest.NewRequest("POST", "/test", nil)
+		ctx.Set("userID", 123)
 		edu := &settingsModels.Education{
 			ID:          1,
 			ProfileID:   1,
@@ -74,6 +75,7 @@ func TestEntityOperations(t *testing.T) {
 		w := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(w)
 		ctx.Request = httptest.NewRequest("POST", "/test", nil)
+		ctx.Set("userID", 123)
 		cert := &settingsModels.Certification{
 			ID:         1,
 			ProfileID:  1,
@@ -95,6 +97,7 @@ func TestEntityOperations(t *testing.T) {
 		w := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(w)
 		ctx.Request = httptest.NewRequest("POST", "/test", nil)
+		ctx.Set("userID", 123)
 
 		cert := &settingsModels.Certification{
 			ID:         1,
@@ -105,7 +108,7 @@ func TestEntityOperations(t *testing.T) {
 
 		// DeleteEntity first calls GetEntityByID to verify entity exists
 		mockProfileRepo.On("GetEntityByID", context.Background(), 1, 1, "Certification").Return(cert, nil).Once()
-		mockProfileRepo.On("DeleteCertification", context.Background(), 1).Return(nil).Once()
+		mockProfileRepo.On("DeleteCertification", context.Background(), 1, 1).Return(nil).Once()
 
 		err := service.DeleteEntity(ctx, 1, 1, "Certification")
 		require.NoError(t, err)
@@ -116,6 +119,7 @@ func TestEntityOperations(t *testing.T) {
 		w := httptest.NewRecorder()
 		ctx, _ := gin.CreateTestContext(w)
 		ctx.Request = httptest.NewRequest("POST", "/test", nil)
+		ctx.Set("userID", 123)
 
 		// GetEntityByID will be called first and should return an error for invalid type
 		mockProfileRepo.On("GetEntityByID", context.Background(), 1, 1, "invalid_type").Return(nil, settingsModels.ErrSettingsNotFound).Once()

--- a/internal/settings/services_test.go
+++ b/internal/settings/services_test.go
@@ -84,8 +84,8 @@ func (m *MockProfileRepository) UpdateWorkExperience(ctx context.Context, exp *s
 	return args.Get(0).(*settingsModels.WorkExperience), args.Error(1)
 }
 
-func (m *MockProfileRepository) DeleteWorkExperience(ctx context.Context, id int) error {
-	args := m.Called(ctx, id)
+func (m *MockProfileRepository) DeleteWorkExperience(ctx context.Context, id int, profileID int) error {
+	args := m.Called(ctx, id, profileID)
 	return args.Error(0)
 }
 
@@ -110,8 +110,8 @@ func (m *MockProfileRepository) UpdateEducation(ctx context.Context, edu *settin
 	return args.Get(0).(*settingsModels.Education), args.Error(1)
 }
 
-func (m *MockProfileRepository) DeleteEducation(ctx context.Context, id int) error {
-	args := m.Called(ctx, id)
+func (m *MockProfileRepository) DeleteEducation(ctx context.Context, id int, profileID int) error {
+	args := m.Called(ctx, id, profileID)
 	return args.Error(0)
 }
 
@@ -136,8 +136,8 @@ func (m *MockProfileRepository) UpdateCertification(ctx context.Context, cert *s
 	return args.Get(0).(*settingsModels.Certification), args.Error(1)
 }
 
-func (m *MockProfileRepository) DeleteCertification(ctx context.Context, id int) error {
-	args := m.Called(ctx, id)
+func (m *MockProfileRepository) DeleteCertification(ctx context.Context, id int, profileID int) error {
+	args := m.Called(ctx, id, profileID)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
## 🚀 What's this about?

This PR fixes two critical issues:
1. **Authentication loop** where users successfully log in but get immediately redirected back to the login page due to browsers rejecting cookies with the `Secure` flag when served over HTTP connections
2. **Security vulnerability** where users could potentially modify other users' profile data due to missing ownership verification

## 💡 Why this matters

- **Authentication issue**: Affects self-hosted users running Vega AI on local machines or VPS servers using HTTP. Since the production build defaults to secure cookies, authentication fails completely on HTTP deployments, making the application unusable.
- **Security issue**: The profile UPDATE/DELETE operations were not verifying user ownership, allowing potential cross-user data manipulation.

## 📝 Changes

### Docker Configuration
- **Dockerfile**: Removed `COOKIE_SECURE` as build arg (now handled at runtime)
- **Entrypoint script**: 
  - Sets `COOKIE_SECURE` based on deployment mode at runtime
  - Cloud mode enforces `COOKIE_SECURE=true` for security
  - Regular mode respects user settings, defaults to `false`
  - Auto-generates TOKEN_SECRET for self-hosted 

### Workflow Updates
- **docker-build-cloud.yml**: Sets `CLOUD_MODE=true` build argument
- Regular build workflow remains unchanged

### Security Fixes
- **Profile Repository**: Added `userID` parameter to all UPDATE/DELETE methods
- **Service Layer**: Updated to pass userID from context to repository methods
- **Interface Updates**: Updated `SettingsRepository` interface with new method signatures
- **Error Handling**: Added `ErrUnauthorized` to settings models

## ✅ Testing Checklist

- [x] Regular build works on `http://localhost:8765`
- [x] Regular build works with HTTPS when `COOKIE_SECURE=true` 
- [x] Cloud build enforces `COOKIE_SECURE=true`
- [x] Cloud build refuses to start without Google OAuth credentials
- [x] All profile UPDATE/DELETE operations verify user ownership
- [x] All tests pass