### PR TITLE
  Add quota system for job analysis limits

### DIFF
--- a/internal/api/job/routes.go
+++ b/internal/api/job/routes.go
@@ -9,5 +9,6 @@ func RegisterRoutes(router *gin.RouterGroup, handler *JobAPIHandler) {
 	jobRoutes := router.Group("")
 	{
 		jobRoutes.POST("", handler.CreateJob)
+		jobRoutes.GET("/quota", handler.GetQuotaStatus)
 	}
 }

--- a/internal/auth/services/auth.go
+++ b/internal/auth/services/auth.go
@@ -162,6 +162,14 @@ func (s *AuthService) RefreshAccessToken(ctx context.Context, refreshToken strin
 		return "", models.ErrInvalidToken
 	}
 
+	if user == nil {
+		s.log.Error().
+			Str("event", "token_refresh_user_nil").
+			Str("user_ref", fmt.Sprintf("user_%d", claims.UserID)).
+			Msg("User not found for token refresh")
+		return "", models.ErrInvalidToken
+	}
+
 	accessToken, err := GenerateAccessToken(user, s.config)
 	if err != nil {
 		s.log.Error().Err(err).

--- a/internal/common/render/render.go
+++ b/internal/common/render/render.go
@@ -24,6 +24,7 @@ func (r *HTMLRenderer) BaseTemplateData(c *gin.Context) gin.H {
 		"currentYear":         time.Now().Year(),
 		"securityPageEnabled": r.cfg.SecurityPageEnabled,
 		"username":            username,
+		"isCloudMode":         r.cfg.IsCloudMode,
 	}
 }
 

--- a/internal/home/handlers.go
+++ b/internal/home/handlers.go
@@ -69,5 +69,6 @@ func (h *Handler) GetHomePage(c *gin.Context) {
 		"recentJobs":     homeData.RecentJobs,
 		"hasJobs":        homeData.HasJobs,
 		"showOnboarding": homeData.ShowOnboarding,
+		"quotaStatus":    homeData.QuotaStatus,
 	})
 }

--- a/internal/home/models.go
+++ b/internal/home/models.go
@@ -1,6 +1,8 @@
 package home
 
 import (
+	"time"
+
 	"github.com/benidevo/vega/internal/job/models"
 )
 
@@ -14,6 +16,16 @@ type HomePageData struct {
 	ShowOnboarding bool            `json:"show_onboarding"`
 	Title          string          `json:"title"`
 	Page           string          `json:"page"`
+	QuotaStatus    *QuotaStatus    `json:"quota_status"`
+}
+
+// QuotaStatus represents the current quota status for a user
+type QuotaStatus struct {
+	Used       int       `json:"used"`
+	Limit      int       `json:"limit"`
+	Remaining  int       `json:"remaining"`
+	ResetDate  time.Time `json:"reset_date"`
+	Percentage int       `json:"percentage"`
 }
 
 // JobStatsSummary provides key metrics for homepage display

--- a/internal/home/setup.go
+++ b/internal/home/setup.go
@@ -5,15 +5,21 @@ import (
 
 	"github.com/benidevo/vega/internal/cache"
 	"github.com/benidevo/vega/internal/config"
+	"github.com/benidevo/vega/internal/job"
 	"github.com/benidevo/vega/internal/job/repository"
 )
 
 // Setup initializes and returns a new home Handler.
-func Setup(db *sql.DB, cfg *config.Settings, cache cache.Cache) *Handler {
+func Setup(db *sql.DB, cfg *config.Settings, cache cache.Cache, jobService *job.JobService) *Handler {
+	homeService := SetupService(db, cache, jobService)
+
+	return NewHandler(cfg, homeService)
+}
+
+// SetupService initializes just the home service without the handler.
+func SetupService(db *sql.DB, cache cache.Cache, jobService *job.JobService) *Service {
 	companyRepo := repository.NewSQLiteCompanyRepository(db, cache)
 	jobRepo := repository.NewSQLiteJobRepository(db, companyRepo, cache)
 
-	homeService := NewService(jobRepo)
-
-	return NewHandler(cfg, homeService)
+	return NewService(jobRepo, jobService)
 }

--- a/internal/job/handlers.go
+++ b/internal/job/handlers.go
@@ -458,6 +458,7 @@ func (h *JobHandler) GetJobDetails(c *gin.Context) {
 			}
 			return (quotaCheckResult.Status.Used * 100) / quotaCheckResult.Status.Limit
 		}(),
+		"isCloudMode": h.cfg.IsCloudMode,
 	})
 }
 

--- a/internal/job/interfaces/repository.go
+++ b/internal/job/interfaces/repository.go
@@ -41,4 +41,8 @@ type JobRepository interface {
 	GetStatsByUserID(ctx context.Context, userID int) (*models.JobStats, error)
 	GetRecentJobsByUserID(ctx context.Context, userID int, limit int) ([]*models.Job, error)
 	GetJobStatsByStatus(ctx context.Context, userID int) (map[models.JobStatus]int, error)
+
+	// Quota-related methods
+	GetMonthlyAnalysisCount(ctx context.Context, userID int) (int, error)
+	SetFirstAnalyzedAt(ctx context.Context, jobID int) error
 }

--- a/internal/job/models/errors.go
+++ b/internal/job/models/errors.go
@@ -43,6 +43,9 @@ var (
 	// Profile validation errors for AI operations
 	ErrProfileIncomplete      = commonerrors.New("please complete your profile to use AI features")
 	ErrProfileSummaryRequired = commonerrors.New("please add a career summary to your profile to use AI features")
+
+	// Quota errors
+	ErrQuotaExceeded = commonerrors.New("monthly quota exceeded")
 )
 
 // WrapError is a convenience function that calls the common errors package

--- a/internal/job/models/job_model.go
+++ b/internal/job/models/job_model.go
@@ -115,21 +115,22 @@ func (j JobType) String() string {
 // Job represents a job posting.
 // It includes metadata for database mapping and JSON serialization.
 type Job struct {
-	ID             int       `json:"id" db:"id" sql:"primary_key;auto_increment"`
-	UserID         int       `json:"user_id" db:"user_id" sql:"not null;index" validate:"required"`
-	Title          string    `json:"title" db:"title" sql:"type:text;not null;index" validate:"required,min=1,max=255"`
-	Description    string    `json:"description" db:"description" sql:"type:text;not null" validate:"required,min=1"`
-	Location       string    `json:"location" db:"location" sql:"type:text" validate:"max=255"`
-	JobType        JobType   `json:"job_type" db:"job_type" sql:"type:integer;not null;default:0" validate:"min=0,max=6"`
-	SourceURL      string    `json:"source_url" db:"source_url" sql:"type:text;index" validate:"omitempty,url"`
-	RequiredSkills []string  `json:"required_skills" db:"required_skills" sql:"type:text" validate:"max=50,dive,max=100"` // Stored as JSON
-	ApplicationURL string    `json:"application_url" db:"application_url" sql:"type:text" validate:"omitempty,url"`
-	Company        Company   `json:"company" sql:"-" validate:"required"` // Not stored directly, company_id is used instead
-	Status         JobStatus `json:"status" db:"status" sql:"type:integer;not null;default:0;index" validate:"min=0,max=5"`
-	MatchScore     *int      `json:"match_score,omitempty" db:"match_score" sql:"type:integer;index" validate:"omitempty,min=0,max=100"`
-	Notes          string    `json:"notes,omitempty" db:"notes" sql:"type:text" validate:"max=5000"`
-	CreatedAt      time.Time `json:"created_at" db:"created_at" sql:"type:timestamp;not null;default:current_timestamp"`
-	UpdatedAt      time.Time `json:"updated_at" db:"updated_at" sql:"type:timestamp;not null;default:current_timestamp"`
+	ID              int        `json:"id" db:"id" sql:"primary_key;auto_increment"`
+	UserID          int        `json:"user_id" db:"user_id" sql:"not null;index" validate:"required"`
+	Title           string     `json:"title" db:"title" sql:"type:text;not null;index" validate:"required,min=1,max=255"`
+	Description     string     `json:"description" db:"description" sql:"type:text;not null" validate:"required,min=1"`
+	Location        string     `json:"location" db:"location" sql:"type:text" validate:"max=255"`
+	JobType         JobType    `json:"job_type" db:"job_type" sql:"type:integer;not null;default:0" validate:"min=0,max=6"`
+	SourceURL       string     `json:"source_url" db:"source_url" sql:"type:text;index" validate:"omitempty,url"`
+	RequiredSkills  []string   `json:"required_skills" db:"required_skills" sql:"type:text" validate:"max=50,dive,max=100"` // Stored as JSON
+	ApplicationURL  string     `json:"application_url" db:"application_url" sql:"type:text" validate:"omitempty,url"`
+	Company         Company    `json:"company" sql:"-" validate:"required"` // Not stored directly, company_id is used instead
+	Status          JobStatus  `json:"status" db:"status" sql:"type:integer;not null;default:0;index" validate:"min=0,max=5"`
+	MatchScore      *int       `json:"match_score,omitempty" db:"match_score" sql:"type:integer;index" validate:"omitempty,min=0,max=100"`
+	Notes           string     `json:"notes,omitempty" db:"notes" sql:"type:text" validate:"max=5000"`
+	CreatedAt       time.Time  `json:"created_at" db:"created_at" sql:"type:timestamp;not null;default:current_timestamp"`
+	UpdatedAt       time.Time  `json:"updated_at" db:"updated_at" sql:"type:timestamp;not null;default:current_timestamp"`
+	FirstAnalyzedAt *time.Time `json:"first_analyzed_at,omitempty" db:"first_analyzed_at" sql:"type:timestamp"`
 
 	// SQL-only fields
 	CompanyID int `json:"-" db:"company_id" sql:"type:integer;not null;index;references:companies(id)"`

--- a/internal/job/repository/job_repository_test.go
+++ b/internal/job/repository/job_repository_test.go
@@ -200,14 +200,14 @@ func TestSQLiteJobRepository_GetByID(t *testing.T) {
 			"j.id", "j.title", "j.description", "j.location", "j.job_type",
 			"j.source_url", "j.required_skills",
 			"j.application_url", "j.company_id", "j.status", "j.match_score",
-			"j.notes", "j.created_at", "j.updated_at", "j.user_id",
-			"c.id", "c.name", "c.created_at", "c.updated_at",
+			"j.notes", "j.created_at", "j.updated_at", "j.user_id", "j.first_analyzed_at",
+			"c.name", "c.created_at", "c.updated_at",
 		}).AddRow(
 			jobID, "Software Engineer", "Build awesome software", "Remote", int(models.FULL_TIME),
 			"https://example.com", `["Go","SQL"]`,
 			"https://apply.example.com", 2, int(models.INTERESTED), 85,
-			"Great company", now.Add(-24*time.Hour), now, testUserID,
-			2, "Acme Corp", now, now,
+			"Great company", now.Add(-24*time.Hour), now, testUserID, nil,
+			"Acme Corp", now, now,
 		)
 
 		mock.ExpectQuery("SELECT.*FROM jobs.*WHERE j.id = \\? AND j.user_id = \\?").
@@ -305,14 +305,14 @@ func TestSQLiteJobRepository_GetAll(t *testing.T) {
 			"j.id", "j.title", "j.description", "j.location", "j.job_type",
 			"j.source_url", "j.required_skills",
 			"j.application_url", "j.company_id", "j.status", "j.match_score",
-			"j.notes", "j.created_at", "j.updated_at", "j.user_id",
-			"c.id", "c.name", "c.created_at", "c.updated_at",
+			"j.notes", "j.created_at", "j.updated_at", "j.user_id", "j.first_analyzed_at",
+			"c.name", "c.created_at", "c.updated_at",
 		}).AddRow(
 			1, "Software Engineer", "Build awesome software", "Remote", int(models.FULL_TIME),
 			"https://example.com", `["Go","SQL"]`,
 			"https://apply.example.com", companyID, int(models.INTERESTED), 92,
-			"Great company", now.Add(-24*time.Hour), now, testUserID,
-			companyID, "Acme Corp", now, now,
+			"Great company", now.Add(-24*time.Hour), now, testUserID, nil,
+			"Acme Corp", now, now,
 		)
 
 		mock.ExpectQuery("SELECT.*FROM jobs.*WHERE.*user_id.*company_id.*ORDER BY").
@@ -517,16 +517,16 @@ func TestGetRecentJobsByUserID(t *testing.T) {
 				rows := sqlmock.NewRows([]string{
 					"id", "title", "description", "location", "job_type",
 					"source_url", "skills", "application_url", "company_id",
-					"status", "match_score", "notes", "created_at", "updated_at", "user_id",
-					"company_id", "company_name", "company_created_at", "company_updated_at",
+					"status", "match_score", "notes", "created_at", "updated_at", "user_id", "first_analyzed_at",
+					"company_name", "company_created_at", "company_updated_at",
 				}).AddRow(
 					1, "Engineer", "Great job", "Remote", int(models.FULL_TIME),
 					"https://example.com", `["Go"]`, "", 1, int(models.APPLIED), 85,
-					"Good fit", now, now, testUserID, 1, "Test Company", now, now,
+					"Good fit", now, now, testUserID, nil, "Test Company", now, now,
 				).AddRow(
 					2, "Developer", "Another job", "NYC", int(models.PART_TIME),
 					"https://example2.com", `["Python"]`, "", 1, int(models.INTERESTED), 75,
-					"Interesting", now, now, testUserID, 1, "Test Company", now, now,
+					"Interesting", now, now, testUserID, nil, "Test Company", now, now,
 				)
 
 				mock.ExpectQuery("SELECT.*FROM jobs.*WHERE.*user_id.*ORDER BY.*LIMIT").
@@ -571,8 +571,8 @@ func TestGetRecentJobsByUserID(t *testing.T) {
 				rows := sqlmock.NewRows([]string{
 					"id", "title", "description", "location", "job_type",
 					"source_url", "skills", "application_url", "company_id",
-					"status", "match_score", "notes", "created_at", "updated_at", "user_id",
-					"company_id", "company_name", "company_created_at", "company_updated_at",
+					"status", "match_score", "notes", "created_at", "updated_at", "user_id", "first_analyzed_at",
+					"company_name", "company_created_at", "company_updated_at",
 				})
 
 				mock.ExpectQuery("SELECT.*FROM jobs.*WHERE.*user_id.*ORDER BY.*LIMIT").

--- a/internal/job/services_ai.go
+++ b/internal/job/services_ai.go
@@ -175,14 +175,13 @@ func (s *JobService) AnalyzeJobMatch(ctx context.Context, userID, jobID int) (*m
 	}
 
 	// Record the analysis in quota system if available
-	if s.quotaService != nil {
+	if s.quotaService != nil && job.FirstAnalyzedAt == nil {
 		if err := s.quotaService.RecordAnalysis(ctx, userID, jobID); err != nil {
 			s.log.Warn().Err(err).
 				Str("user_ref", userRef).
 				Int("job_id", jobID).
 				Str("error_type", "quota_record_failed").
 				Msg("Failed to record analysis in quota system, but analysis completed")
-			// Don't fail the operation if quota recording fails
 		}
 	}
 

--- a/internal/job/services_ai_test.go
+++ b/internal/job/services_ai_test.go
@@ -117,7 +117,7 @@ func TestJobService_AnalyzeJobMatch_NoAIService(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
 
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	result, err := service.AnalyzeJobMatch(context.Background(), 1, 1)
 
@@ -131,7 +131,7 @@ func TestJobService_AnalyzeJobMatch_NoSettingsService(t *testing.T) {
 	cfg := &config.Settings{}
 
 	// Create service with AI service but no settings service
-	service := NewJobService(mockJobRepo, &ai.AIService{}, nil, cfg)
+	service := NewJobService(mockJobRepo, &ai.AIService{}, nil, nil, cfg)
 
 	result, err := service.AnalyzeJobMatch(context.Background(), 1, 1)
 
@@ -144,7 +144,7 @@ func TestJobService_GenerateCoverLetter_NoAIService(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
 
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	result, err := service.GenerateCoverLetter(context.Background(), 1, 1)
 
@@ -232,7 +232,7 @@ func TestJobService_ValidateProfileForAI(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mockJobRepo := &MockJobRepository{}
 			cfg := &config.Settings{}
-			service := NewJobService(mockJobRepo, nil, nil, cfg)
+			service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 			err := service.ValidateProfileForAI(tt.profile)
 
@@ -249,7 +249,7 @@ func TestJobService_ValidateProfileForAI(t *testing.T) {
 func TestJobService_buildAIRequest(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	job := createTestJobForAI()
 	profile := createTestProfile()
@@ -270,7 +270,7 @@ func TestJobService_buildAIRequest(t *testing.T) {
 func TestJobService_buildAIRequest_EmptyName(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	job := createTestJobForAI()
 	profile := createTestProfile()
@@ -285,7 +285,7 @@ func TestJobService_buildAIRequest_EmptyName(t *testing.T) {
 func TestJobService_buildProfileSummary(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	profile := createTestProfile()
 
@@ -309,7 +309,7 @@ func TestJobService_buildProfileSummary(t *testing.T) {
 func TestJobService_buildProfileSummary_LimitedExperience(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	profile := createTestProfile()
 
@@ -336,7 +336,7 @@ func TestJobService_buildProfileSummary_LimitedExperience(t *testing.T) {
 func TestJobService_convertToJobMatchAnalysis(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	aiResult := &aimodels.MatchResult{
 		MatchScore: 85,
@@ -363,7 +363,7 @@ func TestJobService_convertToJobMatchAnalysis(t *testing.T) {
 func TestJobService_convertToCoverLetter(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	aiResult := &aimodels.CoverLetter{
 		Content: "Dear Hiring Manager...",
@@ -385,7 +385,7 @@ func TestJobService_GenerateCV_NoAIService(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
 
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	result, err := service.GenerateCV(context.Background(), 1, 1)
 
@@ -398,7 +398,7 @@ func TestJobService_GenerateCV_NoSettingsService(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
 
-	service := NewJobService(mockJobRepo, &ai.AIService{}, nil, cfg)
+	service := NewJobService(mockJobRepo, &ai.AIService{}, nil, nil, cfg)
 
 	result, err := service.GenerateCV(context.Background(), 1, 1)
 
@@ -410,7 +410,7 @@ func TestJobService_GenerateCV_NoSettingsService(t *testing.T) {
 func TestJobService_calculateTotalExperience(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	tests := []struct {
 		name           string
@@ -497,7 +497,7 @@ func TestJobService_calculateTotalExperience(t *testing.T) {
 func TestJobService_buildAIRequest_ExperienceContext(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	job := createTestJobForAI()
 
@@ -557,7 +557,7 @@ func TestJobService_buildAIRequest_ExperienceContext(t *testing.T) {
 func TestJobService_buildAIRequest_SimilarSkillsHandling(t *testing.T) {
 	mockJobRepo := &MockJobRepository{}
 	cfg := &config.Settings{}
-	service := NewJobService(mockJobRepo, nil, nil, cfg)
+	service := NewJobService(mockJobRepo, nil, nil, nil, cfg)
 
 	// Create a job requiring specific skills
 	job := &models.Job{

--- a/internal/job/services_delete_test.go
+++ b/internal/job/services_delete_test.go
@@ -14,7 +14,7 @@ func TestJobService_DeleteMatchResult(t *testing.T) {
 		// Arrange
 		mockRepo := new(MockJobRepository)
 		cfg := setupTestConfig()
-		service := NewJobService(mockRepo, nil, nil, cfg)
+		service := NewJobService(mockRepo, nil, nil, nil, cfg)
 		ctx := context.Background()
 		jobID := 1
 		matchID := 100
@@ -31,7 +31,7 @@ func TestJobService_DeleteMatchResult(t *testing.T) {
 	t.Run("invalid job ID", func(t *testing.T) {
 		mockRepo := new(MockJobRepository)
 		cfg := setupTestConfig()
-		service := NewJobService(mockRepo, nil, nil, cfg)
+		service := NewJobService(mockRepo, nil, nil, nil, cfg)
 		ctx := context.Background()
 
 		err := service.DeleteMatchResult(ctx, testUserID, 0, 100)
@@ -44,7 +44,7 @@ func TestJobService_DeleteMatchResult(t *testing.T) {
 	t.Run("invalid match ID", func(t *testing.T) {
 		mockRepo := new(MockJobRepository)
 		cfg := setupTestConfig()
-		service := NewJobService(mockRepo, nil, nil, cfg)
+		service := NewJobService(mockRepo, nil, nil, nil, cfg)
 		ctx := context.Background()
 
 		err := service.DeleteMatchResult(ctx, testUserID, 1, 0)
@@ -57,7 +57,7 @@ func TestJobService_DeleteMatchResult(t *testing.T) {
 	t.Run("match result does not belong to job", func(t *testing.T) {
 		mockRepo := new(MockJobRepository)
 		cfg := setupTestConfig()
-		service := NewJobService(mockRepo, nil, nil, cfg)
+		service := NewJobService(mockRepo, nil, nil, nil, cfg)
 		ctx := context.Background()
 		jobID := 1
 		matchID := 100
@@ -74,7 +74,7 @@ func TestJobService_DeleteMatchResult(t *testing.T) {
 	t.Run("error checking match ownership", func(t *testing.T) {
 		mockRepo := new(MockJobRepository)
 		cfg := setupTestConfig()
-		service := NewJobService(mockRepo, nil, nil, cfg)
+		service := NewJobService(mockRepo, nil, nil, nil, cfg)
 		ctx := context.Background()
 		jobID := 1
 		matchID := 100
@@ -93,7 +93,7 @@ func TestJobService_DeleteMatchResult(t *testing.T) {
 		// Arrange
 		mockRepo := new(MockJobRepository)
 		cfg := setupTestConfig()
-		service := NewJobService(mockRepo, nil, nil, cfg)
+		service := NewJobService(mockRepo, nil, nil, nil, cfg)
 		ctx := context.Background()
 		jobID := 1
 		matchID := 100

--- a/internal/job/setup.go
+++ b/internal/job/setup.go
@@ -35,7 +35,7 @@ func SetupService(db *sql.DB, cfg *config.Settings, cache cache.Cache) *JobServi
 
 	// Setup quota service
 	quotaAdapter := quota.NewJobRepositoryAdapter(jobRepo)
-	quotaService := quota.NewService(db, quotaAdapter)
+	quotaService := quota.NewService(db, quotaAdapter, cfg.IsCloudMode)
 
 	jobService := SetupJobService(jobRepo, aiService, settingsService, quotaService, cfg)
 

--- a/internal/quota/models.go
+++ b/internal/quota/models.go
@@ -1,0 +1,47 @@
+package quota
+
+import (
+	"time"
+)
+
+// QuotaUsage represents a user's quota usage for a specific month
+type QuotaUsage struct {
+	UserID       int       `db:"user_id"`
+	MonthYear    string    `db:"month_year"`
+	JobsAnalyzed int       `db:"jobs_analyzed"`
+	UpdatedAt    time.Time `db:"updated_at"`
+}
+
+// QuotaStatus represents the current quota status for a user
+type QuotaStatus struct {
+	Used      int       `json:"used"`
+	Limit     int       `json:"limit"`
+	ResetDate time.Time `json:"reset_date"`
+}
+
+// QuotaCheckResult represents the result of a quota check
+type QuotaCheckResult struct {
+	Allowed bool        `json:"allowed"`
+	Reason  string      `json:"reason"`
+	Status  QuotaStatus `json:"status"`
+}
+
+// Job represents a minimal job structure for quota checking
+type Job struct {
+	ID              int        `db:"id"`
+	FirstAnalyzedAt *time.Time `db:"first_analyzed_at"`
+}
+
+const (
+	// FreeUserMonthlyLimit is the number of new job analyses allowed per month for free users
+	FreeUserMonthlyLimit = 5
+
+	// QuotaReasonOK indicates the operation is allowed
+	QuotaReasonOK = "ok"
+
+	// QuotaReasonReanalysis indicates this is a re-analysis (always allowed)
+	QuotaReasonReanalysis = "re-analysis allowed"
+
+	// QuotaReasonLimitReached indicates the monthly limit has been reached
+	QuotaReasonLimitReached = "Monthly limit of 5 job analyses reached"
+)

--- a/internal/quota/repository_adapter.go
+++ b/internal/quota/repository_adapter.go
@@ -1,0 +1,43 @@
+package quota
+
+import (
+	"context"
+
+	"github.com/benidevo/vega/internal/job/interfaces"
+)
+
+// JobRepositoryAdapter adapts the job repository interface for quota service
+type JobRepositoryAdapter struct {
+	jobRepo interfaces.JobRepository
+}
+
+// NewJobRepositoryAdapter creates a new adapter
+func NewJobRepositoryAdapter(jobRepo interfaces.JobRepository) JobRepository {
+	return &JobRepositoryAdapter{
+		jobRepo: jobRepo,
+	}
+}
+
+// GetByID adapts the job repository GetByID method for quota service
+func (a *JobRepositoryAdapter) GetByID(ctx context.Context, userID, jobID int) (*Job, error) {
+	job, err := a.jobRepo.GetByID(ctx, userID, jobID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to quota Job struct
+	return &Job{
+		ID:              job.ID,
+		FirstAnalyzedAt: job.FirstAnalyzedAt,
+	}, nil
+}
+
+// GetMonthlyAnalysisCount delegates to the job repository
+func (a *JobRepositoryAdapter) GetMonthlyAnalysisCount(ctx context.Context, userID int) (int, error) {
+	return a.jobRepo.GetMonthlyAnalysisCount(ctx, userID)
+}
+
+// SetFirstAnalyzedAt delegates to the job repository
+func (a *JobRepositoryAdapter) SetFirstAnalyzedAt(ctx context.Context, jobID int) error {
+	return a.jobRepo.SetFirstAnalyzedAt(ctx, jobID)
+}

--- a/internal/quota/repository_adapter.go
+++ b/internal/quota/repository_adapter.go
@@ -32,11 +32,6 @@ func (a *JobRepositoryAdapter) GetByID(ctx context.Context, userID, jobID int) (
 	}, nil
 }
 
-// GetMonthlyAnalysisCount delegates to the job repository
-func (a *JobRepositoryAdapter) GetMonthlyAnalysisCount(ctx context.Context, userID int) (int, error) {
-	return a.jobRepo.GetMonthlyAnalysisCount(ctx, userID)
-}
-
 // SetFirstAnalyzedAt delegates to the job repository
 func (a *JobRepositoryAdapter) SetFirstAnalyzedAt(ctx context.Context, jobID int) error {
 	return a.jobRepo.SetFirstAnalyzedAt(ctx, jobID)

--- a/internal/quota/service.go
+++ b/internal/quota/service.go
@@ -1,0 +1,178 @@
+package quota
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// JobRepository interface defines methods the quota service needs from the job repository
+type JobRepository interface {
+	GetByID(ctx context.Context, userID, jobID int) (*Job, error)
+	GetMonthlyAnalysisCount(ctx context.Context, userID int) (int, error)
+	SetFirstAnalyzedAt(ctx context.Context, jobID int) error
+}
+
+// Service handles quota management
+type Service struct {
+	db      *sql.DB
+	jobRepo JobRepository
+}
+
+// NewService creates a new quota service
+func NewService(db *sql.DB, jobRepo JobRepository) *Service {
+	return &Service{
+		db:      db,
+		jobRepo: jobRepo,
+	}
+}
+
+// CanAnalyzeJob checks if a user can analyze a specific job
+func (s *Service) CanAnalyzeJob(ctx context.Context, userID int, jobID int) (*QuotaCheckResult, error) {
+	// 1. Check if job was previously analyzed
+	job, err := s.jobRepo.GetByID(ctx, userID, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get job: %w", err)
+	}
+
+	// Get current usage for status
+	usage, err := s.GetMonthlyUsage(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get monthly usage: %w", err)
+	}
+
+	status := QuotaStatus{
+		Used:      usage.JobsAnalyzed,
+		Limit:     FreeUserMonthlyLimit,
+		ResetDate: getNextMonthStart(),
+	}
+
+	// If job was previously analyzed, it's a re-analysis (always allowed)
+	if job.FirstAnalyzedAt != nil {
+		return &QuotaCheckResult{
+			Allowed: true,
+			Reason:  QuotaReasonReanalysis,
+			Status:  status,
+		}, nil
+	}
+
+	// 2. Check monthly limit for new analyses
+	if usage.JobsAnalyzed >= FreeUserMonthlyLimit {
+		return &QuotaCheckResult{
+			Allowed: false,
+			Reason:  QuotaReasonLimitReached,
+			Status:  status,
+		}, nil
+	}
+
+	return &QuotaCheckResult{
+		Allowed: true,
+		Reason:  QuotaReasonOK,
+		Status:  status,
+	}, nil
+}
+
+// RecordAnalysis records that a job has been analyzed
+func (s *Service) RecordAnalysis(ctx context.Context, userID int, jobID int) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	err = s.jobRepo.SetFirstAnalyzedAt(ctx, jobID)
+	if err != nil {
+		return fmt.Errorf("failed to set first analyzed at: %w", err)
+	}
+
+	monthYear := getCurrentMonthYear()
+
+	updateQuery := `
+		UPDATE user_quota_usage
+		SET jobs_analyzed = jobs_analyzed + 1,
+		    updated_at = CURRENT_TIMESTAMP
+		WHERE user_id = ? AND month_year = ?
+	`
+
+	result, err := tx.ExecContext(ctx, updateQuery, userID, monthYear)
+	if err != nil {
+		return fmt.Errorf("failed to update quota usage: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to check rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		insertQuery := `
+			INSERT INTO user_quota_usage (user_id, month_year, jobs_analyzed, updated_at)
+			VALUES (?, ?, 1, CURRENT_TIMESTAMP)
+		`
+		_, err = tx.ExecContext(ctx, insertQuery, userID, monthYear)
+		if err != nil {
+			return fmt.Errorf("failed to insert quota usage: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// GetMonthlyUsage gets the current month's usage for a user
+func (s *Service) GetMonthlyUsage(ctx context.Context, userID int) (*QuotaUsage, error) {
+	monthYear := getCurrentMonthYear()
+
+	usage := &QuotaUsage{
+		UserID:       userID,
+		MonthYear:    monthYear,
+		JobsAnalyzed: 0,
+		UpdatedAt:    time.Now(),
+	}
+
+	query := `
+		SELECT user_id, month_year, jobs_analyzed, updated_at
+		FROM user_quota_usage
+		WHERE user_id = ? AND month_year = ?
+	`
+
+	row := s.db.QueryRowContext(ctx, query, userID, monthYear)
+	err := row.Scan(&usage.UserID, &usage.MonthYear, &usage.JobsAnalyzed, &usage.UpdatedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			// No usage recorded yet for this month, return zero usage
+			return usage, nil
+		}
+		return nil, fmt.Errorf("failed to get quota usage: %w", err)
+	}
+
+	return usage, nil
+}
+
+// GetQuotaStatus returns the current quota status for a user
+func (s *Service) GetQuotaStatus(ctx context.Context, userID int) (*QuotaStatus, error) {
+	usage, err := s.GetMonthlyUsage(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &QuotaStatus{
+		Used:      usage.JobsAnalyzed,
+		Limit:     FreeUserMonthlyLimit,
+		ResetDate: getNextMonthStart(),
+	}, nil
+}
+
+// getCurrentMonthYear returns the current month in "YYYY-MM" format
+func getCurrentMonthYear() string {
+	return time.Now().Format("2006-01")
+}
+
+// getNextMonthStart returns the first day of next month
+func getNextMonthStart() time.Time {
+	now := time.Now()
+	// Get first day of current month
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	// Add one month
+	return firstOfMonth.AddDate(0, 1, 0)
+}

--- a/internal/quota/service.go
+++ b/internal/quota/service.go
@@ -10,7 +10,6 @@ import (
 // JobRepository interface defines methods the quota service needs from the job repository
 type JobRepository interface {
 	GetByID(ctx context.Context, userID, jobID int) (*Job, error)
-	GetMonthlyAnalysisCount(ctx context.Context, userID int) (int, error)
 	SetFirstAnalyzedAt(ctx context.Context, jobID int) error
 }
 

--- a/internal/quota/service_test.go
+++ b/internal/quota/service_test.go
@@ -32,11 +32,6 @@ func (m *MockJobRepository) GetByID(ctx context.Context, userID, jobID int) (*Jo
 	return args.Get(0).(*Job), args.Error(1)
 }
 
-func (m *MockJobRepository) GetMonthlyAnalysisCount(ctx context.Context, userID int) (int, error) {
-	args := m.Called(ctx, userID)
-	return args.Int(0), args.Error(1)
-}
-
 func (m *MockJobRepository) SetFirstAnalyzedAt(ctx context.Context, jobID int) error {
 	args := m.Called(ctx, jobID)
 	return args.Error(0)
@@ -62,7 +57,6 @@ func TestService_NonCloudMode(t *testing.T) {
 
 		// Should not call any repository methods in non-cloud mode
 		mockRepo.AssertNotCalled(t, "GetByID")
-		mockRepo.AssertNotCalled(t, "GetMonthlyAnalysisCount")
 	})
 
 	t.Run("GetQuotaStatus returns unlimited quota", func(t *testing.T) {

--- a/internal/quota/service_test.go
+++ b/internal/quota/service_test.go
@@ -1,0 +1,290 @@
+package quota
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// setupMockDB creates a new mock database for testing
+func setupMockDB(t *testing.T) (*sql.DB, sqlmock.Sqlmock) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	return db, mock
+}
+
+// MockJobRepository is a mock implementation of JobRepository
+type MockJobRepository struct {
+	mock.Mock
+}
+
+func (m *MockJobRepository) GetByID(ctx context.Context, userID, jobID int) (*Job, error) {
+	args := m.Called(ctx, userID, jobID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*Job), args.Error(1)
+}
+
+func (m *MockJobRepository) GetMonthlyAnalysisCount(ctx context.Context, userID int) (int, error) {
+	args := m.Called(ctx, userID)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockJobRepository) SetFirstAnalyzedAt(ctx context.Context, jobID int) error {
+	args := m.Called(ctx, jobID)
+	return args.Error(0)
+}
+
+func TestService_NonCloudMode(t *testing.T) {
+	ctx := context.Background()
+	userID := 1
+	jobID := 100
+
+	t.Run("CanAnalyzeJob returns unlimited access", func(t *testing.T) {
+		mockRepo := new(MockJobRepository)
+		service := NewService(nil, mockRepo, false) // Non-cloud mode
+		
+		result, err := service.CanAnalyzeJob(ctx, userID, jobID)
+		
+		assert.NoError(t, err)
+		assert.True(t, result.Allowed)
+		assert.Equal(t, QuotaReasonOK, result.Reason)
+		assert.Equal(t, -1, result.Status.Limit) // Unlimited
+		assert.Equal(t, 0, result.Status.Used)
+		assert.Equal(t, time.Time{}, result.Status.ResetDate)
+		
+		// Should not call any repository methods in non-cloud mode
+		mockRepo.AssertNotCalled(t, "GetByID")
+		mockRepo.AssertNotCalled(t, "GetMonthlyAnalysisCount")
+	})
+
+	t.Run("GetQuotaStatus returns unlimited quota", func(t *testing.T) {
+		mockRepo := new(MockJobRepository)
+		service := NewService(nil, mockRepo, false) // Non-cloud mode
+		
+		status, err := service.GetQuotaStatus(ctx, userID)
+		
+		assert.NoError(t, err)
+		assert.Equal(t, -1, status.Limit) // Unlimited
+		assert.Equal(t, 0, status.Used)
+		assert.Equal(t, time.Time{}, status.ResetDate)
+	})
+
+	t.Run("RecordAnalysis does nothing", func(t *testing.T) {
+		mockRepo := new(MockJobRepository)
+		service := NewService(nil, mockRepo, false) // Non-cloud mode
+		
+		err := service.RecordAnalysis(ctx, userID, jobID)
+		
+		assert.NoError(t, err)
+		
+		// Should not call any repository methods
+		mockRepo.AssertNotCalled(t, "SetFirstAnalyzedAt")
+	})
+
+	t.Run("GetMonthlyUsage returns zero usage", func(t *testing.T) {
+		mockRepo := new(MockJobRepository)
+		service := NewService(nil, mockRepo, false) // Non-cloud mode
+		
+		usage, err := service.GetMonthlyUsage(ctx, userID)
+		
+		assert.NoError(t, err)
+		assert.Equal(t, userID, usage.UserID)
+		assert.Equal(t, 0, usage.JobsAnalyzed)
+		assert.Equal(t, getCurrentMonthYear(), usage.MonthYear)
+	})
+}
+
+func TestService_CloudMode(t *testing.T) {
+	ctx := context.Background()
+	userID := 1
+	jobID := 100
+
+	t.Run("CanAnalyzeJob enforces quota for new analysis", func(t *testing.T) {
+		db, mock := setupMockDB(t)
+		defer db.Close()
+
+		mockRepo := new(MockJobRepository)
+		service := NewService(db, mockRepo, true) // Cloud mode enabled
+
+		// Mock job that hasn't been analyzed
+		job := &Job{ID: jobID, FirstAnalyzedAt: nil}
+		mockRepo.On("GetByID", ctx, userID, jobID).Return(job, nil).Once()
+
+		// Mock GetMonthlyUsage query - no existing usage
+		monthYear := getCurrentMonthYear()
+		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").
+			WithArgs(userID, monthYear).
+			WillReturnError(sql.ErrNoRows)
+
+		result, err := service.CanAnalyzeJob(ctx, userID, jobID)
+
+		assert.NoError(t, err)
+		assert.True(t, result.Allowed)
+		assert.Equal(t, QuotaReasonOK, result.Reason)
+		assert.Equal(t, FreeUserMonthlyLimit, result.Status.Limit)
+		assert.Equal(t, 0, result.Status.Used)
+		
+		mockRepo.AssertExpectations(t)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("CanAnalyzeJob blocks when limit reached", func(t *testing.T) {
+		db, mock := setupMockDB(t)
+		defer db.Close()
+
+		mockRepo := new(MockJobRepository)
+		service := NewService(db, mockRepo, true) // Cloud mode enabled
+
+		// Mock job that hasn't been analyzed
+		job := &Job{ID: jobID, FirstAnalyzedAt: nil}
+		mockRepo.On("GetByID", ctx, userID, jobID).Return(job, nil).Once()
+
+		// Mock GetMonthlyUsage query - at limit
+		monthYear := getCurrentMonthYear()
+		rows := sqlmock.NewRows([]string{"user_id", "month_year", "jobs_analyzed", "updated_at"}).
+			AddRow(userID, monthYear, FreeUserMonthlyLimit, time.Now())
+		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").
+			WithArgs(userID, monthYear).
+			WillReturnRows(rows)
+
+		result, err := service.CanAnalyzeJob(ctx, userID, jobID)
+
+		assert.NoError(t, err)
+		assert.False(t, result.Allowed)
+		assert.Equal(t, QuotaReasonLimitReached, result.Reason)
+		assert.Equal(t, FreeUserMonthlyLimit, result.Status.Limit)
+		assert.Equal(t, FreeUserMonthlyLimit, result.Status.Used)
+		
+		mockRepo.AssertExpectations(t)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("CanAnalyzeJob allows reanalysis", func(t *testing.T) {
+		db, mock := setupMockDB(t)
+		defer db.Close()
+
+		mockRepo := new(MockJobRepository)
+		service := NewService(db, mockRepo, true) // Cloud mode enabled
+
+		// Mock job that has been analyzed before
+		analyzedAt := time.Now()
+		job := &Job{ID: jobID, FirstAnalyzedAt: &analyzedAt}
+		mockRepo.On("GetByID", ctx, userID, jobID).Return(job, nil).Once()
+
+		// Mock GetMonthlyUsage query - even if at limit, reanalysis is allowed
+		monthYear := getCurrentMonthYear()
+		rows := sqlmock.NewRows([]string{"user_id", "month_year", "jobs_analyzed", "updated_at"}).
+			AddRow(userID, monthYear, FreeUserMonthlyLimit, time.Now())
+		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").
+			WithArgs(userID, monthYear).
+			WillReturnRows(rows)
+
+		result, err := service.CanAnalyzeJob(ctx, userID, jobID)
+
+		assert.NoError(t, err)
+		assert.True(t, result.Allowed)
+		assert.Equal(t, QuotaReasonReanalysis, result.Reason)
+		
+		mockRepo.AssertExpectations(t)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("RecordAnalysis creates new usage record", func(t *testing.T) {
+		db, mock := setupMockDB(t)
+		defer db.Close()
+
+		mockRepo := new(MockJobRepository)
+		service := NewService(db, mockRepo, true) // Cloud mode enabled
+
+		// Mock SetFirstAnalyzedAt
+		mockRepo.On("SetFirstAnalyzedAt", ctx, jobID).Return(nil).Once()
+
+		monthYear := getCurrentMonthYear()
+
+		// Begin transaction
+		mock.ExpectBegin()
+
+		// Expect UPDATE attempt first
+		mock.ExpectExec("UPDATE user_quota_usage SET jobs_analyzed = jobs_analyzed \\+ 1").
+			WithArgs(userID, monthYear).
+			WillReturnResult(sqlmock.NewResult(0, 0)) // No rows affected
+
+		// Since no rows were updated, expect INSERT
+		mock.ExpectExec("INSERT INTO user_quota_usage \\(user_id, month_year, jobs_analyzed, updated_at\\) VALUES \\(\\?, \\?, 1, CURRENT_TIMESTAMP\\)").
+			WithArgs(userID, monthYear).
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		// Commit transaction
+		mock.ExpectCommit()
+
+		err := service.RecordAnalysis(ctx, userID, jobID)
+
+		assert.NoError(t, err)
+		mockRepo.AssertExpectations(t)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("RecordAnalysis increments existing usage", func(t *testing.T) {
+		db, mock := setupMockDB(t)
+		defer db.Close()
+
+		mockRepo := new(MockJobRepository)
+		service := NewService(db, mockRepo, true) // Cloud mode enabled
+
+		// Mock SetFirstAnalyzedAt
+		mockRepo.On("SetFirstAnalyzedAt", ctx, jobID).Return(nil).Once()
+
+		monthYear := getCurrentMonthYear()
+
+		// Begin transaction
+		mock.ExpectBegin()
+
+		// Expect UPDATE to succeed
+		mock.ExpectExec("UPDATE user_quota_usage SET jobs_analyzed = jobs_analyzed \\+ 1").
+			WithArgs(userID, monthYear).
+			WillReturnResult(sqlmock.NewResult(0, 1)) // 1 row affected
+
+		// Commit transaction
+		mock.ExpectCommit()
+
+		err := service.RecordAnalysis(ctx, userID, jobID)
+
+		assert.NoError(t, err)
+		mockRepo.AssertExpectations(t)
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("GetQuotaStatus returns correct usage", func(t *testing.T) {
+		db, mock := setupMockDB(t)
+		defer db.Close()
+
+		mockRepo := new(MockJobRepository)
+		service := NewService(db, mockRepo, true) // Cloud mode enabled
+
+		// Mock GetMonthlyUsage query
+		monthYear := getCurrentMonthYear()
+		usedCount := 5
+		rows := sqlmock.NewRows([]string{"user_id", "month_year", "jobs_analyzed", "updated_at"}).
+			AddRow(userID, monthYear, usedCount, time.Now())
+		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").
+			WithArgs(userID, monthYear).
+			WillReturnRows(rows)
+
+		status, err := service.GetQuotaStatus(ctx, userID)
+
+		assert.NoError(t, err)
+		assert.Equal(t, FreeUserMonthlyLimit, status.Limit)
+		assert.Equal(t, usedCount, status.Used)
+		assert.NotEqual(t, time.Time{}, status.ResetDate)
+		
+		assert.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/internal/vega/routes.go
+++ b/internal/vega/routes.go
@@ -33,11 +33,13 @@ func SetupRoutes(a *App) {
 	}
 
 	authHandler := auth.SetupAuth(a.db, &a.config)
-	homeHandler := home.Setup(a.db, &a.config, a.cache)
-	jobHandler := job.Setup(a.db, &a.config, a.cache)
+	jobService := job.SetupService(a.db, &a.config, a.cache)
+	jobHandler := job.NewJobHandler(jobService, &a.config)
 	settingsHandler := settings.Setup(&a.config, a.db, aiService)
 	authAPIHandler := authapi.Setup(a.db, &a.config)
 	jobAPIHandler := jobapi.Setup(a.db, &a.config, a.cache)
+
+	homeHandler := home.Setup(a.db, &a.config, a.cache, jobService)
 
 	authGroup := a.router.Group("/auth")
 

--- a/migrations/sqlite/000003_add_quota_system.down.sql
+++ b/migrations/sqlite/000003_add_quota_system.down.sql
@@ -1,0 +1,36 @@
+-- Drop quota tracking index
+DROP INDEX IF EXISTS idx_user_quota_month;
+
+-- Drop user quota usage table
+DROP TABLE IF EXISTS user_quota_usage;
+
+-- SQLite doesn't support dropping columns, so we need to recreate the table
+-- This is the existing jobs table structure without first_analyzed_at
+CREATE TABLE jobs_temp (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    company TEXT NOT NULL,
+    title TEXT NOT NULL,
+    url TEXT,
+    description TEXT,
+    location TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    analyzed_at TIMESTAMP,
+    match_score REAL,
+    analysis_result TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Copy data from current jobs table
+INSERT INTO jobs_temp SELECT id, user_id, company, title, url, description, location, created_at, updated_at, analyzed_at, match_score, analysis_result FROM jobs;
+
+-- Drop the old table
+DROP TABLE jobs;
+
+-- Rename temp table to jobs
+ALTER TABLE jobs_temp RENAME TO jobs;
+
+-- Recreate indexes
+CREATE INDEX idx_jobs_user_id ON jobs(user_id);
+CREATE INDEX idx_jobs_created_at ON jobs(created_at);

--- a/migrations/sqlite/000003_add_quota_system.down.sql
+++ b/migrations/sqlite/000003_add_quota_system.down.sql
@@ -9,21 +9,26 @@ DROP TABLE IF EXISTS user_quota_usage;
 CREATE TABLE jobs_temp (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     user_id INTEGER NOT NULL,
-    company TEXT NOT NULL,
     title TEXT NOT NULL,
-    url TEXT,
-    description TEXT,
+    description TEXT NOT NULL,
     location TEXT,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    analyzed_at TIMESTAMP,
-    match_score REAL,
-    analysis_result TEXT,
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    job_type INTEGER NOT NULL DEFAULT 0,
+    source_url TEXT,
+    required_skills TEXT, -- JSON array
+    application_url TEXT,
+    company_id INTEGER NOT NULL,
+    status INTEGER NOT NULL DEFAULT 0,
+    match_score INTEGER,
+    notes TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (company_id) REFERENCES companies(id),
+    CHECK (match_score IS NULL OR (match_score >= 0 AND match_score <= 100))
 );
 
--- Copy data from current jobs table
-INSERT INTO jobs_temp SELECT id, user_id, company, title, url, description, location, created_at, updated_at, analyzed_at, match_score, analysis_result FROM jobs;
+-- Copy data from current jobs table (excluding first_analyzed_at)
+INSERT INTO jobs_temp SELECT id, user_id, title, description, location, job_type, source_url, required_skills, application_url, company_id, status, match_score, notes, created_at, updated_at FROM jobs;
 
 -- Drop the old table
 DROP TABLE jobs;
@@ -33,4 +38,10 @@ ALTER TABLE jobs_temp RENAME TO jobs;
 
 -- Recreate indexes
 CREATE INDEX idx_jobs_user_id ON jobs(user_id);
-CREATE INDEX idx_jobs_created_at ON jobs(created_at);
+CREATE INDEX idx_jobs_title ON jobs(title);
+CREATE INDEX idx_jobs_status ON jobs(status);
+CREATE INDEX idx_jobs_match_score ON jobs(match_score);
+CREATE INDEX idx_jobs_company_id ON jobs(company_id);
+CREATE UNIQUE INDEX idx_jobs_user_id_source_url ON jobs(user_id, source_url);
+CREATE INDEX idx_jobs_user_id_status ON jobs(user_id, status);
+CREATE INDEX idx_jobs_user_id_created_at ON jobs(user_id, created_at DESC);

--- a/migrations/sqlite/000003_add_quota_system.up.sql
+++ b/migrations/sqlite/000003_add_quota_system.up.sql
@@ -1,0 +1,15 @@
+-- Add quota tracking to jobs table
+ALTER TABLE jobs ADD COLUMN first_analyzed_at TIMESTAMP;
+
+-- Create user quota usage tracking table
+CREATE TABLE IF NOT EXISTS user_quota_usage (
+    user_id INTEGER PRIMARY KEY,
+    month_year TEXT NOT NULL,  -- Format: "2024-01"
+    jobs_analyzed INTEGER DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(user_id, month_year),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Create index for efficient quota lookups
+CREATE INDEX idx_user_quota_month ON user_quota_usage(user_id, month_year);

--- a/migrations/sqlite/000003_add_quota_system.up.sql
+++ b/migrations/sqlite/000003_add_quota_system.up.sql
@@ -3,11 +3,11 @@ ALTER TABLE jobs ADD COLUMN first_analyzed_at TIMESTAMP;
 
 -- Create user quota usage tracking table
 CREATE TABLE IF NOT EXISTS user_quota_usage (
-    user_id INTEGER PRIMARY KEY,
+    user_id INTEGER NOT NULL,
     month_year TEXT NOT NULL,  -- Format: "2024-01"
     jobs_analyzed INTEGER DEFAULT 0,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(user_id, month_year),
+    PRIMARY KEY (user_id, month_year),
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
 

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -93,6 +93,37 @@
     </div>
   </section>
 
+  {{if .quotaStatus}}
+  {{if and .quotaStatus.Limit (gt .quotaStatus.Limit 0)}}
+  <!-- Quota Usage Widget -->
+  <section class="mb-8 sm:mb-12" aria-labelledby="quota-heading">
+    <h2 id="quota-heading" class="text-lg sm:text-xl font-semibold text-white mb-4 font-heading">AI Analysis Quota</h2>
+    <div class="bg-slate-800 rounded-lg p-4 sm:p-6 border border-slate-700">
+      <div class="flex items-center justify-between mb-4">
+        <div>
+          <h3 class="text-base font-medium text-white">Monthly Job Analyses</h3>
+          <p class="text-sm text-gray-400 mt-1">{{.quotaStatus.Used}} of {{.quotaStatus.Limit}} used</p>
+        </div>
+        <div class="text-right">
+          <p class="text-2xl font-bold {{if eq .quotaStatus.Remaining 0}}text-red-400{{else}}text-primary{{end}}">{{.quotaStatus.Remaining}}</p>
+          <p class="text-xs text-gray-400">remaining</p>
+        </div>
+      </div>
+      
+      <!-- Progress bar -->
+      <div class="w-full bg-gray-700 rounded-full h-3 mb-3">
+        <div class="{{if eq .quotaStatus.Remaining 0}}bg-red-500{{else if le .quotaStatus.Remaining 1}}bg-yellow-500{{else}}bg-primary{{end}} rounded-full h-3 transition-all duration-300" style="width: {{.quotaStatus.Percentage}}%"></div>
+      </div>
+      
+      <div class="flex items-center justify-between text-xs text-gray-400">
+        <span>Resets on {{.quotaStatus.ResetDate.Format "Jan 2"}}</span>
+        <span class="text-gray-300">Re-analysis of existing jobs is always free</span>
+      </div>
+    </div>
+  </section>
+  {{end}}
+  {{end}}
+
   <!-- Quick Actions -->
   <section class="mb-8 sm:mb-12" aria-labelledby="quick-actions-heading">
     <h2 id="quick-actions-heading" class="text-lg sm:text-xl font-semibold text-white mb-4 font-heading">Quick Actions</h2>

--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -94,7 +94,7 @@
   </section>
 
   {{if .quotaStatus}}
-  {{if and .quotaStatus.Limit (gt .quotaStatus.Limit 0)}}
+  {{if gt .quotaStatus.Limit 0}}
   <!-- Quota Usage Widget -->
   <section class="mb-8 sm:mb-12" aria-labelledby="quota-heading">
     <h2 id="quota-heading" class="text-lg sm:text-xl font-semibold text-white mb-4 font-heading">AI Analysis Quota</h2>

--- a/templates/job/details.html
+++ b/templates/job/details.html
@@ -241,7 +241,7 @@
           <div id="status-response"></div>
 
           {{if .isCloudMode}}
-          {{if .quotaCheck.Status.Limit}}
+          {{if gt .quotaCheck.Status.Limit 0}}
           {{if and (not .isReanalysis) (not .quotaCheck.Allowed)}}
           <!-- Quota exceeded message -->
           <div class="w-full mb-3 p-3 bg-red-900 bg-opacity-30 border border-red-800 rounded-lg">
@@ -287,7 +287,7 @@
           </button>
           
           {{if .isCloudMode}}
-          {{if and .quotaCheck.Status.Limit (gt .quotaCheck.Status.Limit 0)}}
+          {{if gt .quotaCheck.Status.Limit 0}}
           <!-- Quota usage indicator -->
           <div class="w-full mb-3">
             <div class="flex justify-between text-xs text-gray-400 mb-1">

--- a/templates/job/details.html
+++ b/templates/job/details.html
@@ -240,12 +240,24 @@
           </select>
           <div id="status-response"></div>
 
-          <button id="analyze-button" class="w-full mb-3 py-2.5 px-4 bg-primary hover:bg-primary-dark text-white rounded-md text-sm font-medium transition-colors flex items-center justify-center gap-2 whitespace-nowrap"
+          {{if .quotaCheck.Status.Limit}}
+          {{if and (not .isReanalysis) (not .quotaCheck.Allowed)}}
+          <!-- Quota exceeded message -->
+          <div class="w-full mb-3 p-3 bg-red-900 bg-opacity-30 border border-red-800 rounded-lg">
+            <p class="text-red-400 text-sm font-medium">Monthly Limit Reached</p>
+            <p class="text-gray-400 text-xs mt-1">You've used all {{.quotaCheck.Status.Limit}} job analyses this month. Limit resets on {{.quotaCheck.Status.ResetDate.Format "Jan 2"}}.</p>
+          </div>
+          {{end}}
+          {{end}}
+          
+          <button id="analyze-button" class="w-full mb-3 py-2.5 px-4 {{if and (not .isReanalysis) (not .quotaCheck.Allowed)}}bg-gray-600 cursor-not-allowed{{else}}bg-primary hover:bg-primary-dark{{end}} text-white rounded-md text-sm font-medium transition-colors flex items-center justify-center gap-2 whitespace-nowrap"
+                  {{if and (not .isReanalysis) (not .quotaCheck.Allowed)}}disabled{{else}}
                   hx-post="/jobs/{{.jobID}}/analyze"
                   hx-target="#ai-analysis"
                   hx-target-error="#analyze-error"
                   hx-swap="innerHTML"
-                  hx-indicator="#analyze-spinner">
+                  hx-indicator="#analyze-spinner"
+                  {{end}}>
             <span id="analyze-spinner" class="htmx-indicator">
               <svg class="animate-spin h-5 w-5 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -257,8 +269,29 @@
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
               </svg>
             </span>
-            <span>Analyze Match</span>
+            <span>
+              {{if .isReanalysis}}
+                Re-analyze Job (Free)
+              {{else if .quotaCheck.Allowed}}
+                Analyze Match ({{.quotaRemaining}} left)
+              {{else}}
+                Monthly Limit Reached
+              {{end}}
+            </span>
           </button>
+          
+          {{if and .quotaCheck.Status.Limit (gt .quotaCheck.Status.Limit 0)}}
+          <!-- Quota usage indicator -->
+          <div class="w-full mb-3">
+            <div class="flex justify-between text-xs text-gray-400 mb-1">
+              <span>Monthly quota</span>
+              <span>{{.quotaCheck.Status.Used}}/{{.quotaCheck.Status.Limit}} used</span>
+            </div>
+            <div class="w-full bg-gray-700 rounded-full h-2">
+              <div class="bg-primary rounded-full h-2 transition-all duration-300" style="width: {{.quotaPercentage}}%"></div>
+            </div>
+          </div>
+          {{end}}
 
           <!-- Error display for analyze button -->
           <div id="analyze-error"></div>

--- a/templates/job/details.html
+++ b/templates/job/details.html
@@ -240,6 +240,7 @@
           </select>
           <div id="status-response"></div>
 
+          {{if .isCloudMode}}
           {{if .quotaCheck.Status.Limit}}
           {{if and (not .isReanalysis) (not .quotaCheck.Allowed)}}
           <!-- Quota exceeded message -->
@@ -249,9 +250,10 @@
           </div>
           {{end}}
           {{end}}
+          {{end}}
           
-          <button id="analyze-button" class="w-full mb-3 py-2.5 px-4 {{if and (not .isReanalysis) (not .quotaCheck.Allowed)}}bg-gray-600 cursor-not-allowed{{else}}bg-primary hover:bg-primary-dark{{end}} text-white rounded-md text-sm font-medium transition-colors flex items-center justify-center gap-2 whitespace-nowrap"
-                  {{if and (not .isReanalysis) (not .quotaCheck.Allowed)}}disabled{{else}}
+          <button id="analyze-button" class="w-full mb-3 py-2.5 px-4 {{if and .isCloudMode (not .isReanalysis) (not .quotaCheck.Allowed)}}bg-gray-600 cursor-not-allowed{{else}}bg-primary hover:bg-primary-dark{{end}} text-white rounded-md text-sm font-medium transition-colors flex items-center justify-center gap-2 whitespace-nowrap"
+                  {{if and .isCloudMode (not .isReanalysis) (not .quotaCheck.Allowed)}}disabled{{else}}
                   hx-post="/jobs/{{.jobID}}/analyze"
                   hx-target="#ai-analysis"
                   hx-target-error="#analyze-error"
@@ -272,14 +274,19 @@
             <span>
               {{if .isReanalysis}}
                 Re-analyze Job (Free)
-              {{else if .quotaCheck.Allowed}}
-                Analyze Match ({{.quotaRemaining}} left)
+              {{else if .isCloudMode}}
+                {{if .quotaCheck.Allowed}}
+                  Analyze Match ({{.quotaRemaining}} left)
+                {{else}}
+                  Monthly Limit Reached
+                {{end}}
               {{else}}
-                Monthly Limit Reached
+                Analyze Match
               {{end}}
             </span>
           </button>
           
+          {{if .isCloudMode}}
           {{if and .quotaCheck.Status.Limit (gt .quotaCheck.Status.Limit 0)}}
           <!-- Quota usage indicator -->
           <div class="w-full mb-3">
@@ -291,6 +298,7 @@
               <div class="bg-primary rounded-full h-2 transition-all duration-300" style="width: {{.quotaPercentage}}%"></div>
             </div>
           </div>
+          {{end}}
           {{end}}
 
           <!-- Error display for analyze button -->

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -24,6 +24,7 @@
         <div class="flex items-center space-x-2">
           <span class="text-primary font-medium">Vega AI</span>
         </div>
+        {{if not .isCloudMode}}
         <div class="flex items-center space-x-2">
           <a href="https://github.com/benidevo/vega-ai" 
              class="text-primary hover:text-primary-dark transition-colors duration-200 underline decoration-1 underline-offset-2"
@@ -37,6 +38,7 @@
             </span>
           </a>
         </div>
+        {{end}}
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 🚀 What's this about?

This PR implements a quota system to limit the number of job analyses users can perform per month in cloud mode. Users get 5 free job analyses per month, with unlimited re-analyses of previously analyzed jobs.

## 💡 Why this matters

In cloud mode deployments, we need to manage resource usage and prevent abuse. This quota system:

- Limits new job analyses to 5 per month for free users
- Allows unlimited re-analysis of jobs already analyzed
- Resets automatically at the start of each month
- Only enforces limits in cloud mode (local deployments remain unlimited)

## ✅ How was this tested?

- [x] Tested locally
- [x] All tests pass
- [x] Manually verified the change works as expected

