### PR TITLE
Add Job Search Preferences

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,10 +36,12 @@ GOOGLE_CLIENT_REDIRECT_URL=http://localhost:8765/auth/google/callback
 # GOOGLE_AUTH_USER_INFO_SCOPE=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/drive.file
 
 # Admin User Creation (for first-time setup)
-CREATE_ADMIN_USER=false
-ADMIN_USERNAME=admin
-ADMIN_PASSWORD=change-this-secure-password
-ADMIN_EMAIL=admin@example.com
+# In self-hosted mode, an admin user is automatically created with:
+# Username: admin, Password: VegaAdmin
+# You can override these defaults:
+# ADMIN_USERNAME=admin
+# ADMIN_PASSWORD=your-secure-password
+# RESET_ADMIN_PASSWORD=true # Uncomment to reset admin password on startup
 
 # =============================================================================
 # CLOUD MODE FEATURES

--- a/README.md
+++ b/README.md
@@ -27,26 +27,18 @@ Create a file called `config` in the vega-ai folder with this content (replace y
 
 ```bash
 GEMINI_API_KEY=your-gemini-api-key
-CREATE_ADMIN_USER=true
+```
+
+**For Self-Hosted Deployments:**
+
+If you're running Vega AI on your own server (not using cloud mode), you can create an admin user by adding these lines:
+
+```bash
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=your-secure-password
 ```
 
-**Password Requirements:**
-
-- Must be at least 8 characters long
-- Maximum 64 characters
-- Use a strong, unique password for security
-
-**Username Requirements:**
-
-- Must be 3-50 characters long
-- Can contain letters, numbers, and common symbols
-
-**Optional Admin Settings:**
-
-- Add `RESET_ADMIN_PASSWORD=true` to reset admin password if user already exists
-- See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for advanced configuration options
+See [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md) for advanced configuration options
 
 ### 2. Run with Docker
 

--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/goccy/go-json v0.10.5 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect

--- a/internal/api/preferences/handlers.go
+++ b/internal/api/preferences/handlers.go
@@ -1,0 +1,62 @@
+package preferences
+
+import (
+	"net/http"
+
+	"github.com/benidevo/vega/internal/settings"
+	"github.com/gin-gonic/gin"
+)
+
+// PreferencesHandler manages API requests for job search preferences
+type PreferencesHandler struct {
+	settingsService *settings.SettingsService
+}
+
+// NewPreferencesHandler creates a new PreferencesHandler instance
+func NewPreferencesHandler(settingsService *settings.SettingsService) *PreferencesHandler {
+	return &PreferencesHandler{
+		settingsService: settingsService,
+	}
+}
+
+// GetActivePreferences returns active job search preferences for the authenticated user
+func (h *PreferencesHandler) GetActivePreferences(c *gin.Context) {
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "Unauthorized",
+		})
+		return
+	}
+	userID := userIDValue.(int)
+
+	preferences, err := h.settingsService.GetActivePreferences(c.Request.Context(), userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to retrieve preferences",
+		})
+		return
+	}
+
+	// Transform preferences to API response format
+	type preferenceResponse struct {
+		ID       string `json:"id"`
+		JobTitle string `json:"job_title"`
+		Location string `json:"location"`
+		MaxAge   int    `json:"max_age"`
+	}
+
+	var response []preferenceResponse
+	for _, pref := range preferences {
+		response = append(response, preferenceResponse{
+			ID:       pref.ID,
+			JobTitle: pref.JobTitle,
+			Location: pref.Location,
+			MaxAge:   pref.MaxAge,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"preferences": response,
+	})
+}

--- a/internal/api/preferences/routes.go
+++ b/internal/api/preferences/routes.go
@@ -1,0 +1,11 @@
+package preferences
+
+import "github.com/gin-gonic/gin"
+
+// RegisterRoutes registers preference-related API routes
+func RegisterRoutes(apiGroup *gin.RouterGroup, handler *PreferencesHandler) {
+	preferencesGroup := apiGroup.Group("/preferences")
+	{
+		preferencesGroup.GET("/active", handler.GetActivePreferences)
+	}
+}

--- a/internal/api/preferences/routes.go
+++ b/internal/api/preferences/routes.go
@@ -7,5 +7,6 @@ func RegisterRoutes(apiGroup *gin.RouterGroup, handler *PreferencesHandler) {
 	preferencesGroup := apiGroup.Group("/preferences")
 	{
 		preferencesGroup.GET("/active", handler.GetActivePreferences)
+		preferencesGroup.POST("/search-results", handler.RecordJobSearchResults)
 	}
 }

--- a/internal/api/preferences/setup.go
+++ b/internal/api/preferences/setup.go
@@ -1,12 +1,13 @@
 package preferences
 
 import (
+	"github.com/benidevo/vega/internal/quota"
 	"github.com/benidevo/vega/internal/settings"
 	"github.com/gin-gonic/gin"
 )
 
 // Setup initializes the preferences API module
-func Setup(apiGroup *gin.RouterGroup, settingsService *settings.SettingsService) {
-	handler := NewPreferencesHandler(settingsService)
+func Setup(apiGroup *gin.RouterGroup, settingsService *settings.SettingsService, quotaService *quota.UnifiedService) {
+	handler := NewPreferencesHandler(settingsService, quotaService)
 	RegisterRoutes(apiGroup, handler)
 }

--- a/internal/api/preferences/setup.go
+++ b/internal/api/preferences/setup.go
@@ -1,0 +1,12 @@
+package preferences
+
+import (
+	"github.com/benidevo/vega/internal/settings"
+	"github.com/gin-gonic/gin"
+)
+
+// Setup initializes the preferences API module
+func Setup(apiGroup *gin.RouterGroup, settingsService *settings.SettingsService) {
+	handler := NewPreferencesHandler(settingsService)
+	RegisterRoutes(apiGroup, handler)
+}

--- a/internal/auth/models/user.go
+++ b/internal/auth/models/user.go
@@ -6,6 +6,19 @@ import (
 	"time"
 )
 
+// ValidateUsername validates a username
+func ValidateUsername(username string) error {
+	if username == "" {
+		return errors.New("username cannot be empty")
+	}
+
+	if len(username) < 3 || len(username) > 30 {
+		return errors.New("username must be between 3 and 30 characters")
+	}
+
+	return nil
+}
+
 // Role represents the role of a user in the system.
 // It is an enumerated type with predefined constants for different roles.
 //
@@ -67,8 +80,8 @@ func (u *User) IsAdmin() bool {
 
 // NewUser creates a new User instance with the provided username, password, and role.
 func NewUser(username, password string, role Role) (*User, error) {
-	if username == "" {
-		return nil, errors.New("username cannot be empty")
+	if err := ValidateUsername(username); err != nil {
+		return nil, err
 	}
 
 	if password == "" {

--- a/internal/auth/models/user.go
+++ b/internal/auth/models/user.go
@@ -60,6 +60,11 @@ type User struct {
 	LastLogin time.Time `json:"last_login" db:"last_login"`
 }
 
+// IsAdmin returns true if the user has admin role
+func (u *User) IsAdmin() bool {
+	return u.Role == ADMIN
+}
+
 // NewUser creates a new User instance with the provided username, password, and role.
 func NewUser(username, password string, role Role) (*User, error) {
 	if username == "" {

--- a/internal/auth/services/auth.go
+++ b/internal/auth/services/auth.go
@@ -278,6 +278,11 @@ func (s *AuthService) ChangePassword(ctx context.Context, userID int, newPasswor
 	return nil
 }
 
+// VerifyPassword checks if the provided password matches the hashed password
+func (s *AuthService) VerifyPassword(hashedPassword, password string) bool {
+	return verifyPassword(hashedPassword, password)
+}
+
 // TokenType defines the type of JWT token
 type TokenType string
 

--- a/internal/common/alerts/helper.go
+++ b/internal/common/alerts/helper.go
@@ -58,10 +58,8 @@ func RenderErrorWithConfig(c *gin.Context, statusCode int, message string, conte
 			"currentYear": time.Now().Year(),
 		}
 
-		// Add security page enabled flag if config is provided
-		if cfg != nil {
-			templateData["securityPageEnabled"] = cfg.SecurityPageEnabled
-		}
+		// Security page is always enabled
+		templateData["securityPageEnabled"] = true
 
 		c.HTML(http.StatusInternalServerError, "layouts/base.html", templateData)
 		return

--- a/internal/common/context/context.go
+++ b/internal/common/context/context.go
@@ -1,0 +1,24 @@
+package context
+
+import (
+	"context"
+)
+
+// Define context keys as custom types to avoid collisions
+type contextKey string
+
+const (
+	// UserRoleKey is the context key for user role
+	UserRoleKey contextKey = "userRole"
+)
+
+// WithRole adds the user role to the context
+func WithRole(ctx context.Context, role string) context.Context {
+	return context.WithValue(ctx, UserRoleKey, role)
+}
+
+// GetRole retrieves the user role from the context
+func GetRole(ctx context.Context) (string, bool) {
+	role, ok := ctx.Value(UserRoleKey).(string)
+	return role, ok
+}

--- a/internal/common/render/render.go
+++ b/internal/common/render/render.go
@@ -22,7 +22,7 @@ func (r *HTMLRenderer) BaseTemplateData(c *gin.Context) gin.H {
 	username, _ := c.Get("username")
 	return gin.H{
 		"currentYear":         time.Now().Year(),
-		"securityPageEnabled": r.cfg.SecurityPageEnabled,
+		"securityPageEnabled": true, // Always enabled
 		"username":            username,
 		"isCloudMode":         r.cfg.IsCloudMode,
 	}

--- a/internal/common/time/utils.go
+++ b/internal/common/time/utils.go
@@ -1,0 +1,117 @@
+package time
+
+import (
+	"time"
+)
+
+// GetCurrentDate returns the current date in "2006-01-02" format (UTC)
+func GetCurrentDate() string {
+	return time.Now().UTC().Format("2006-01-02")
+}
+
+// GetCurrentMonthYear returns the current month-year in "2006-01" format (UTC)
+func GetCurrentMonthYear() string {
+	return time.Now().UTC().Format("2006-01")
+}
+
+// GetNextMonthStart returns the start of the next month
+func GetNextMonthStart() time.Time {
+	now := time.Now().UTC()
+	// Get first day of current month
+	firstDayOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	// Add one month
+	return firstDayOfMonth.AddDate(0, 1, 0)
+}
+
+// GetFirstDayOfMonth returns the first day of the current month
+func GetFirstDayOfMonth() time.Time {
+	now := time.Now().UTC()
+	return time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+}
+
+// GetLastDayOfMonth returns the last day of the current month
+func GetLastDayOfMonth() time.Time {
+	now := time.Now().UTC()
+	firstDayOfNextMonth := time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, time.UTC)
+	return firstDayOfNextMonth.Add(-24 * time.Hour)
+}
+
+// FormatDate formats a time.Time to "2006-01-02" format
+func FormatDate(t time.Time) string {
+	return t.Format("2006-01-02")
+}
+
+// FormatMonthYear formats a time.Time to "2006-01" format
+func FormatMonthYear(t time.Time) string {
+	return t.Format("2006-01")
+}
+
+// ParseDate parses a date string in "2006-01-02" format
+func ParseDate(dateStr string) (time.Time, error) {
+	return time.Parse("2006-01-02", dateStr)
+}
+
+// ParseMonthYear parses a month-year string in "2006-01" format
+func ParseMonthYear(monthYearStr string) (time.Time, error) {
+	return time.Parse("2006-01", monthYearStr)
+}
+
+// GetDaysInMonth returns the number of days in the current month
+func GetDaysInMonth() int {
+	now := time.Now().UTC()
+	return GetDaysInMonthForDate(now)
+}
+
+// GetDaysInMonthForDate returns the number of days in the month of the given date
+func GetDaysInMonthForDate(date time.Time) int {
+	firstDayOfNextMonth := time.Date(date.Year(), date.Month()+1, 1, 0, 0, 0, 0, time.UTC)
+	lastDayOfMonth := firstDayOfNextMonth.Add(-24 * time.Hour)
+	return lastDayOfMonth.Day()
+}
+
+// GetRemainingDaysInMonth returns the number of days remaining in the current month
+func GetRemainingDaysInMonth() int {
+	now := time.Now().UTC()
+	daysInMonth := GetDaysInMonth()
+	return daysInMonth - now.Day() + 1 // +1 to include today
+}
+
+// IsNewMonth checks if the given date is in a different month than today
+func IsNewMonth(date time.Time) bool {
+	now := time.Now().UTC()
+	return date.Month() != now.Month() || date.Year() != now.Year()
+}
+
+// IsNewDay checks if the given date is a different day than today
+func IsNewDay(date time.Time) bool {
+	now := time.Now().UTC()
+	return !IsSameDay(date, now)
+}
+
+// IsSameDay checks if two dates are on the same day
+func IsSameDay(t1, t2 time.Time) bool {
+	y1, m1, d1 := t1.Date()
+	y2, m2, d2 := t2.Date()
+	return y1 == y2 && m1 == m2 && d1 == d2
+}
+
+// IsSameMonth checks if two dates are in the same month
+func IsSameMonth(t1, t2 time.Time) bool {
+	y1, m1, _ := t1.Date()
+	y2, m2, _ := t2.Date()
+	return y1 == y2 && m1 == m2
+}
+
+// GetMonthStartEnd returns the start and end of the current month
+func GetMonthStartEnd() (time.Time, time.Time) {
+	start := GetFirstDayOfMonth()
+	end := GetLastDayOfMonth()
+	return start, end
+}
+
+// GetTomorrowStart returns the start of tomorrow (midnight UTC)
+func GetTomorrowStart() time.Time {
+	now := time.Now().UTC()
+	tomorrow := now.AddDate(0, 0, 1)
+	return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -44,10 +44,7 @@ type Settings struct {
 	CreateAdminUser    bool
 	AdminUsername      string
 	AdminPassword      string
-	AdminEmail         string
 	ResetAdminPassword bool
-
-	SecurityPageEnabled bool
 
 	AIProvider             string
 	GeminiAPIKey           string
@@ -147,13 +144,12 @@ func NewSettings() Settings {
 		CORSAllowedOrigins:   corsOrigins,
 		CORSAllowCredentials: false,
 
-		CreateAdminUser:    getEnv("CREATE_ADMIN_USER", "false") == "true",
-		AdminUsername:      getEnv("ADMIN_USERNAME", ""),
-		AdminPassword:      getEnv("ADMIN_PASSWORD", ""),
+		// In self-hosted mode, always create admin user if it doesn't exist
+		// In cloud mode, admin user creation is disabled
+		CreateAdminUser:    !isCloudMode,
+		AdminUsername:      getEnv("ADMIN_USERNAME", "admin"),
+		AdminPassword:      getEnv("ADMIN_PASSWORD", "VegaAdmin"),
 		ResetAdminPassword: getEnv("RESET_ADMIN_PASSWORD", "false") == "true",
-		AdminEmail:         getEnv("ADMIN_EMAIL", ""),
-
-		SecurityPageEnabled: isCloudMode, // Security page is only available in cloud mode
 
 		AIProvider:             "gemini",
 		GeminiAPIKey:           getEnv("GEMINI_API_KEY", ""),

--- a/internal/job/handlers.go
+++ b/internal/job/handlers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/benidevo/vega/internal/common/alerts"
+	ctxutil "github.com/benidevo/vega/internal/common/context"
 	"github.com/benidevo/vega/internal/common/render"
 	"github.com/benidevo/vega/internal/config"
 	"github.com/benidevo/vega/internal/job/models"
@@ -577,7 +578,14 @@ func (h *JobHandler) AnalyzeJobMatch(c *gin.Context) {
 	}
 	userID := userIDValue.(int)
 
-	analysis, err := h.service.AnalyzeJobMatch(c.Request.Context(), userID, jobID)
+	ctx := c.Request.Context()
+	if roleValue, exists := c.Get("role"); exists {
+		if role, ok := roleValue.(string); ok {
+			ctx = ctxutil.WithRole(ctx, role)
+		}
+	}
+
+	analysis, err := h.service.AnalyzeJobMatch(ctx, userID, jobID)
 	if err != nil {
 		// Check for quota exceeded error
 		if errors.Is(err, models.ErrQuotaExceeded) {

--- a/internal/job/setup.go
+++ b/internal/job/setup.go
@@ -53,12 +53,12 @@ func SetupAIService(cfg *config.Settings) (*ai.AIService, error) {
 	return ai.Setup(cfg)
 }
 
-// SetupSettingsService initializes and returns a settings service instance.
+// SetupSettingsService initializes and returns a settings service instance for profile management.
 func SetupSettingsService(db *sql.DB, cfg *config.Settings) *settings.SettingsService {
-	// Create the service directly instead of using Setup which returns handler
+	// Create the service for profile management only (no auth needed)
 	authRepo := authrepo.NewSQLiteUserRepository(db)
 	settingsRepo := settingsrepo.NewProfileRepository(db)
-	return settings.NewSettingsService(settingsRepo, cfg, authRepo)
+	return settings.NewSettingsServiceForProfiles(settingsRepo, cfg, authRepo)
 }
 
 // SetupJobService initializes and returns a new JobService using the provided JobRepository, AIService, SettingsService, QuotaService and configuration settings.

--- a/internal/quota/models.go
+++ b/internal/quota/models.go
@@ -32,8 +32,33 @@ type Job struct {
 	FirstAnalyzedAt *time.Time `db:"first_analyzed_at"`
 }
 
+// DailyQuota represents daily quota usage
+type DailyQuota struct {
+	UserID    int       `db:"user_id"`
+	Date      string    `db:"date"`
+	QuotaKey  string    `db:"quota_key"`
+	Value     int       `db:"value"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+// UnifiedQuotaStatus combines all quota statuses
+type UnifiedQuotaStatus struct {
+	AIAnalysis QuotaStatus `json:"ai_analysis"`
+	JobSearch  QuotaStatus `json:"job_search"`
+	SearchRuns QuotaStatus `json:"search_runs"`
+}
+
 const (
-	// FreeUserMonthlyLimit is the number of new job analyses allowed per month for free users
+	// Quota types
+	QuotaTypeAIAnalysis = "ai_analysis"
+	QuotaTypeJobSearch  = "job_search"
+	QuotaTypeSearchRuns = "search_runs"
+
+	// Period types
+	PeriodDaily   = "daily"
+	PeriodMonthly = "monthly"
+
+	// Existing constants
 	FreeUserMonthlyLimit = 5
 
 	// QuotaReasonOK indicates the operation is allowed
@@ -44,4 +69,12 @@ const (
 
 	// QuotaReasonLimitReached indicates the monthly limit has been reached
 	QuotaReasonLimitReached = "Monthly limit of 5 job analyses reached"
+
+	// Daily quota limits for free users
+	FreeUserDailyJobSearchLimit = 100
+	FreeUserDailySearchRunLimit = 20
+
+	// Daily quota keys
+	QuotaKeyJobsFound   = "jobs_found"
+	QuotaKeySearchesRun = "searches_run"
 )

--- a/internal/quota/models.go
+++ b/internal/quota/models.go
@@ -48,6 +48,15 @@ type UnifiedQuotaStatus struct {
 	SearchRuns QuotaStatus `json:"search_runs"`
 }
 
+// QuotaConfig represents quota configuration from database
+type QuotaConfig struct {
+	QuotaType   string    `db:"quota_type"`
+	FreeLimit   int       `db:"free_limit"`
+	Description string    `db:"description"`
+	CreatedAt   time.Time `db:"created_at"`
+	UpdatedAt   time.Time `db:"updated_at"`
+}
+
 const (
 	// Quota types
 	QuotaTypeAIAnalysis = "ai_analysis"
@@ -58,21 +67,14 @@ const (
 	PeriodDaily   = "daily"
 	PeriodMonthly = "monthly"
 
-	// Existing constants
-	FreeUserMonthlyLimit = 5
-
 	// QuotaReasonOK indicates the operation is allowed
 	QuotaReasonOK = "ok"
 
 	// QuotaReasonReanalysis indicates this is a re-analysis (always allowed)
 	QuotaReasonReanalysis = "re-analysis allowed"
 
-	// QuotaReasonLimitReached indicates the monthly limit has been reached
-	QuotaReasonLimitReached = "Monthly limit of 5 job analyses reached"
-
-	// Daily quota limits for free users
-	FreeUserDailyJobSearchLimit = 100
-	FreeUserDailySearchRunLimit = 20
+	// QuotaReasonLimitReached indicates the quota limit has been reached
+	QuotaReasonLimitReached = "quota limit reached"
 
 	// Daily quota keys
 	QuotaKeyJobsFound   = "jobs_found"

--- a/internal/quota/repository.go
+++ b/internal/quota/repository.go
@@ -1,0 +1,150 @@
+package quota
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// Repository interface defines methods for quota data access
+type Repository interface {
+	// Monthly quota methods (existing functionality)
+	GetMonthlyUsage(ctx context.Context, userID int, monthYear string) (*QuotaUsage, error)
+	IncrementMonthlyUsage(ctx context.Context, userID int, monthYear string) error
+
+	// Daily quota methods (new functionality)
+	GetDailyUsage(ctx context.Context, userID int, date string, quotaKey string) (int, error)
+	IncrementDailyUsage(ctx context.Context, userID int, date string, quotaKey string, amount int) error
+	GetAllDailyUsage(ctx context.Context, userID int, date string) (map[string]int, error)
+}
+
+// repository implements the Repository interface
+type repository struct {
+	db *sql.DB
+}
+
+// NewRepository creates a new quota repository
+func NewRepository(db *sql.DB) Repository {
+	return &repository{db: db}
+}
+
+// GetMonthlyUsage gets the monthly usage for a user
+func (r *repository) GetMonthlyUsage(ctx context.Context, userID int, monthYear string) (*QuotaUsage, error) {
+	usage := &QuotaUsage{
+		UserID:       userID,
+		MonthYear:    monthYear,
+		JobsAnalyzed: 0,
+		UpdatedAt:    time.Now(),
+	}
+
+	query := `
+		SELECT user_id, month_year, jobs_analyzed, updated_at
+		FROM user_quota_usage
+		WHERE user_id = ? AND month_year = ?
+	`
+
+	row := r.db.QueryRowContext(ctx, query, userID, monthYear)
+	err := row.Scan(&usage.UserID, &usage.MonthYear, &usage.JobsAnalyzed, &usage.UpdatedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			// No usage recorded yet for this month, return zero usage
+			return usage, nil
+		}
+		return nil, fmt.Errorf("failed to get quota usage: %w", err)
+	}
+
+	return usage, nil
+}
+
+// IncrementMonthlyUsage increments the monthly usage count
+func (r *repository) IncrementMonthlyUsage(ctx context.Context, userID int, monthYear string) error {
+	// Use UPSERT pattern to avoid race conditions
+	upsertQuery := `
+		INSERT INTO user_quota_usage (user_id, month_year, jobs_analyzed, updated_at)
+		VALUES (?, ?, 1, CURRENT_TIMESTAMP)
+		ON CONFLICT(user_id, month_year) DO UPDATE SET
+			jobs_analyzed = jobs_analyzed + 1,
+			updated_at = CURRENT_TIMESTAMP
+	`
+
+	_, err := r.db.ExecContext(ctx, upsertQuery, userID, monthYear)
+	if err != nil {
+		return fmt.Errorf("failed to update quota usage: %w", err)
+	}
+
+	return nil
+}
+
+// GetDailyUsage gets the daily usage for a specific quota key
+func (r *repository) GetDailyUsage(ctx context.Context, userID int, date string, quotaKey string) (int, error) {
+	var value int
+
+	query := `
+		SELECT value
+		FROM user_daily_quotas
+		WHERE user_id = ? AND date = ? AND quota_key = ?
+	`
+
+	row := r.db.QueryRowContext(ctx, query, userID, date, quotaKey)
+	err := row.Scan(&value)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			// No usage recorded yet, return 0
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to get daily quota usage: %w", err)
+	}
+
+	return value, nil
+}
+
+// IncrementDailyUsage increments the daily usage for a specific quota key
+func (r *repository) IncrementDailyUsage(ctx context.Context, userID int, date string, quotaKey string, amount int) error {
+	// Use UPSERT pattern
+	upsertQuery := `
+		INSERT INTO user_daily_quotas (user_id, date, quota_key, value, updated_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+		ON CONFLICT(user_id, date, quota_key) DO UPDATE SET
+			value = value + ?,
+			updated_at = CURRENT_TIMESTAMP
+	`
+
+	_, err := r.db.ExecContext(ctx, upsertQuery, userID, date, quotaKey, amount, amount)
+	if err != nil {
+		return fmt.Errorf("failed to update daily quota usage: %w", err)
+	}
+
+	return nil
+}
+
+// GetAllDailyUsage gets all daily quota usage for a user on a specific date
+func (r *repository) GetAllDailyUsage(ctx context.Context, userID int, date string) (map[string]int, error) {
+	query := `
+		SELECT quota_key, value
+		FROM user_daily_quotas
+		WHERE user_id = ? AND date = ?
+	`
+
+	rows, err := r.db.QueryContext(ctx, query, userID, date)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query daily quota usage: %w", err)
+	}
+	defer rows.Close()
+
+	usage := make(map[string]int)
+	for rows.Next() {
+		var key string
+		var value int
+		if err := rows.Scan(&key, &value); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+		usage[key] = value
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating rows: %w", err)
+	}
+
+	return usage, nil
+}

--- a/internal/quota/search_quota_service.go
+++ b/internal/quota/search_quota_service.go
@@ -1,0 +1,169 @@
+package quota
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// SearchQuotaService handles search-related quota management
+type SearchQuotaService struct {
+	repo        Repository
+	isCloudMode bool
+}
+
+// NewSearchQuotaService creates a new search quota service
+func NewSearchQuotaService(repo Repository, isCloudMode bool) *SearchQuotaService {
+	return &SearchQuotaService{
+		repo:        repo,
+		isCloudMode: isCloudMode,
+	}
+}
+
+// CanSearchJobs checks if a user can search for more jobs
+func (s *SearchQuotaService) CanSearchJobs(ctx context.Context, userID int) (*QuotaCheckResult, error) {
+	today := getCurrentDate()
+	usage, err := s.repo.GetDailyUsage(ctx, userID, today, QuotaKeyJobsFound)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get job search usage: %w", err)
+	}
+
+	if !s.isCloudMode {
+		// In self-hosted mode, always allow but show actual usage
+		return &QuotaCheckResult{
+			Allowed: true,
+			Reason:  QuotaReasonOK,
+			Status: QuotaStatus{
+				Used:      usage,
+				Limit:     -1,
+				ResetDate: time.Time{},
+			},
+		}, nil
+	}
+
+	// Cloud mode: enforce limits
+	limit := FreeUserDailyJobSearchLimit
+	status := QuotaStatus{
+		Used:      usage,
+		Limit:     limit,
+		ResetDate: getTomorrowStart(),
+	}
+
+	if usage >= limit {
+		return &QuotaCheckResult{
+			Allowed: false,
+			Reason:  fmt.Sprintf("Daily limit of %d jobs reached", limit),
+			Status:  status,
+		}, nil
+	}
+
+	return &QuotaCheckResult{
+		Allowed: true,
+		Reason:  QuotaReasonOK,
+		Status:  status,
+	}, nil
+}
+
+// CanRunSearch checks if a user can run another search
+func (s *SearchQuotaService) CanRunSearch(ctx context.Context, userID int) (*QuotaCheckResult, error) {
+	today := getCurrentDate()
+	usage, err := s.repo.GetDailyUsage(ctx, userID, today, QuotaKeySearchesRun)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get search run usage: %w", err)
+	}
+
+	if !s.isCloudMode {
+		// In self-hosted mode, always allow but show actual usage
+		return &QuotaCheckResult{
+			Allowed: true,
+			Reason:  QuotaReasonOK,
+			Status: QuotaStatus{
+				Used:      usage,
+				Limit:     -1,
+				ResetDate: time.Time{},
+			},
+		}, nil
+	}
+
+	// Cloud mode: enforce limits
+	limit := FreeUserDailySearchRunLimit
+	status := QuotaStatus{
+		Used:      usage,
+		Limit:     limit,
+		ResetDate: getTomorrowStart(),
+	}
+
+	if usage >= limit {
+		return &QuotaCheckResult{
+			Allowed: false,
+			Reason:  fmt.Sprintf("Daily limit of %d searches reached", limit),
+			Status:  status,
+		}, nil
+	}
+
+	return &QuotaCheckResult{
+		Allowed: true,
+		Reason:  QuotaReasonOK,
+		Status:  status,
+	}, nil
+}
+
+// RecordJobsFound records that jobs were found
+func (s *SearchQuotaService) RecordJobsFound(ctx context.Context, userID int, count int) error {
+	// Always record usage for tracking purposes
+	today := getCurrentDate()
+	return s.repo.IncrementDailyUsage(ctx, userID, today, QuotaKeyJobsFound, count)
+}
+
+// RecordSearchRun records that a search was run
+func (s *SearchQuotaService) RecordSearchRun(ctx context.Context, userID int) error {
+	// Always record usage for tracking purposes
+	today := getCurrentDate()
+	return s.repo.IncrementDailyUsage(ctx, userID, today, QuotaKeySearchesRun, 1)
+}
+
+// GetStatus returns the current search quota status
+func (s *SearchQuotaService) GetStatus(ctx context.Context, userID int) (*QuotaCheckResult, error) {
+	today := getCurrentDate()
+	jobsFound, err := s.repo.GetDailyUsage(ctx, userID, today, QuotaKeyJobsFound)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get job search usage: %w", err)
+	}
+
+	if !s.isCloudMode {
+		// In self-hosted mode, return actual usage but unlimited limit
+		return &QuotaCheckResult{
+			Allowed: true,
+			Reason:  QuotaReasonOK,
+			Status: QuotaStatus{
+				Used:      jobsFound,
+				Limit:     -1,
+				ResetDate: time.Time{},
+			},
+		}, nil
+	}
+
+	// Cloud mode: enforce limits
+	limit := FreeUserDailyJobSearchLimit
+	return &QuotaCheckResult{
+		Allowed: jobsFound < limit,
+		Reason:  QuotaReasonOK,
+		Status: QuotaStatus{
+			Used:      jobsFound,
+			Limit:     limit,
+			ResetDate: getTomorrowStart(),
+		},
+	}, nil
+}
+
+// getCurrentDate returns the current date in "2006-01-02" format (UTC)
+func getCurrentDate() string {
+	return time.Now().UTC().Format("2006-01-02")
+}
+
+// getTomorrowStart returns the start of tomorrow (UTC)
+func getTomorrowStart() time.Time {
+	now := time.Now().UTC()
+	tomorrow := now.AddDate(0, 0, 1)
+	return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, time.UTC)
+}

--- a/internal/quota/search_quota_service.go
+++ b/internal/quota/search_quota_service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	ctxutil "github.com/benidevo/vega/internal/common/context"
+	timeutil "github.com/benidevo/vega/internal/common/time"
 )
 
 // SearchQuotaService handles search-related quota management
@@ -30,7 +31,7 @@ func (s *SearchQuotaService) isUserAdmin(ctx context.Context) bool {
 
 // CanSearchJobs checks if a user can search for more jobs
 func (s *SearchQuotaService) CanSearchJobs(ctx context.Context, userID int) (*QuotaCheckResult, error) {
-	today := getCurrentDate()
+	today := timeutil.GetCurrentDate()
 	usage, err := s.repo.GetDailyUsage(ctx, userID, today, QuotaKeyJobsFound)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get job search usage: %w", err)
@@ -72,7 +73,7 @@ func (s *SearchQuotaService) CanSearchJobs(ctx context.Context, userID int) (*Qu
 	status := QuotaStatus{
 		Used:      usage,
 		Limit:     limit,
-		ResetDate: getTomorrowStart(),
+		ResetDate: timeutil.GetTomorrowStart(),
 	}
 
 	if usage >= limit {
@@ -92,7 +93,7 @@ func (s *SearchQuotaService) CanSearchJobs(ctx context.Context, userID int) (*Qu
 
 // CanRunSearch checks if a user can run another search
 func (s *SearchQuotaService) CanRunSearch(ctx context.Context, userID int) (*QuotaCheckResult, error) {
-	today := getCurrentDate()
+	today := timeutil.GetCurrentDate()
 	usage, err := s.repo.GetDailyUsage(ctx, userID, today, QuotaKeySearchesRun)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get search run usage: %w", err)
@@ -134,7 +135,7 @@ func (s *SearchQuotaService) CanRunSearch(ctx context.Context, userID int) (*Quo
 	status := QuotaStatus{
 		Used:      usage,
 		Limit:     limit,
-		ResetDate: getTomorrowStart(),
+		ResetDate: timeutil.GetTomorrowStart(),
 	}
 
 	if usage >= limit {
@@ -155,20 +156,20 @@ func (s *SearchQuotaService) CanRunSearch(ctx context.Context, userID int) (*Quo
 // RecordJobsFound records that jobs were found
 func (s *SearchQuotaService) RecordJobsFound(ctx context.Context, userID int, count int) error {
 	// Always record usage for tracking purposes
-	today := getCurrentDate()
+	today := timeutil.GetCurrentDate()
 	return s.repo.IncrementDailyUsage(ctx, userID, today, QuotaKeyJobsFound, count)
 }
 
 // RecordSearchRun records that a search was run
 func (s *SearchQuotaService) RecordSearchRun(ctx context.Context, userID int) error {
 	// Always record usage for tracking purposes
-	today := getCurrentDate()
+	today := timeutil.GetCurrentDate()
 	return s.repo.IncrementDailyUsage(ctx, userID, today, QuotaKeySearchesRun, 1)
 }
 
 // GetStatus returns the current search quota status
 func (s *SearchQuotaService) GetStatus(ctx context.Context, userID int) (*QuotaCheckResult, error) {
-	today := getCurrentDate()
+	today := timeutil.GetCurrentDate()
 	jobsFound, err := s.repo.GetDailyUsage(ctx, userID, today, QuotaKeyJobsFound)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get job search usage: %w", err)
@@ -213,26 +214,14 @@ func (s *SearchQuotaService) GetStatus(ctx context.Context, userID int) (*QuotaC
 		Status: QuotaStatus{
 			Used:      jobsFound,
 			Limit:     limit,
-			ResetDate: getTomorrowStart(),
+			ResetDate: timeutil.GetTomorrowStart(),
 		},
 	}, nil
 }
 
-// getCurrentDate returns the current date in "2006-01-02" format (UTC)
-func getCurrentDate() string {
-	return time.Now().UTC().Format("2006-01-02")
-}
-
-// getTomorrowStart returns the start of tomorrow (UTC)
-func getTomorrowStart() time.Time {
-	now := time.Now().UTC()
-	tomorrow := now.AddDate(0, 0, 1)
-	return time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 0, 0, 0, 0, time.UTC)
-}
-
 // GetSearchRunStatus returns the current search run quota status
 func (s *SearchQuotaService) GetSearchRunStatus(ctx context.Context, userID int) (*QuotaCheckResult, error) {
-	today := getCurrentDate()
+	today := timeutil.GetCurrentDate()
 	searchesRun, err := s.repo.GetDailyUsage(ctx, userID, today, QuotaKeySearchesRun)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get search run usage: %w", err)
@@ -277,7 +266,7 @@ func (s *SearchQuotaService) GetSearchRunStatus(ctx context.Context, userID int)
 		Status: QuotaStatus{
 			Used:      searchesRun,
 			Limit:     limit,
-			ResetDate: getTomorrowStart(),
+			ResetDate: timeutil.GetTomorrowStart(),
 		},
 	}, nil
 }

--- a/internal/quota/service_test.go
+++ b/internal/quota/service_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	ctxutil "github.com/benidevo/vega/internal/common/context"
+	timeutil "github.com/benidevo/vega/internal/common/time"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -72,7 +73,7 @@ func TestService_NonCloudMode(t *testing.T) {
 		mockJobRepo.On("GetByID", ctx, userID, jobID).Return(job, nil).Once()
 
 		// Mock GetMonthlyUsage query - no existing usage
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").
 			WithArgs(userID, monthYear).
 			WillReturnError(sql.ErrNoRows)
@@ -98,7 +99,7 @@ func TestService_NonCloudMode(t *testing.T) {
 		service := NewService(db, mockJobRepo, false) // Non-cloud mode
 
 		// Mock GetMonthlyUsage query - no existing usage
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").
 			WithArgs(userID, monthYear).
 			WillReturnError(sql.ErrNoRows)
@@ -123,7 +124,7 @@ func TestService_NonCloudMode(t *testing.T) {
 		// Mock SetFirstAnalyzedAt
 		mockJobRepo.On("SetFirstAnalyzedAt", ctx, jobID).Return(nil).Once()
 
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 
 		// Begin transaction
 		mock.ExpectBegin()
@@ -151,7 +152,7 @@ func TestService_NonCloudMode(t *testing.T) {
 		service := NewService(db, mockJobRepo, false) // Non-cloud mode
 
 		// Mock GetMonthlyUsage query - with some existing usage
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 		usedCount := 3
 		rows := sqlmock.NewRows([]string{"user_id", "month_year", "jobs_analyzed", "updated_at"}).
 			AddRow(userID, monthYear, usedCount, time.Now())
@@ -164,7 +165,7 @@ func TestService_NonCloudMode(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, userID, usage.UserID)
 		assert.Equal(t, usedCount, usage.JobsAnalyzed)
-		assert.Equal(t, getCurrentMonthYear(), usage.MonthYear)
+		assert.Equal(t, timeutil.GetCurrentMonthYear(), usage.MonthYear)
 
 		assert.NoError(t, mock.ExpectationsWereMet())
 	})
@@ -187,7 +188,7 @@ func TestService_CloudMode(t *testing.T) {
 		mockRepo.On("GetByID", ctx, userID, jobID).Return(job, nil).Once()
 
 		// Mock GetMonthlyUsage query - no existing usage
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").
 			WithArgs(userID, monthYear).
 			WillReturnError(sql.ErrNoRows)
@@ -219,7 +220,7 @@ func TestService_CloudMode(t *testing.T) {
 		mockRepo.On("GetByID", ctx, userID, jobID).Return(job, nil).Once()
 
 		// Mock GetMonthlyUsage query - at limit
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 		rows := sqlmock.NewRows([]string{"user_id", "month_year", "jobs_analyzed", "updated_at"}).
 			AddRow(userID, monthYear, testMonthlyQuotaLimit, time.Now())
 		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").
@@ -254,7 +255,7 @@ func TestService_CloudMode(t *testing.T) {
 		mockRepo.On("GetByID", ctx, userID, jobID).Return(job, nil).Once()
 
 		// Mock GetMonthlyUsage query - even if at limit, reanalysis is allowed
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 		rows := sqlmock.NewRows([]string{"user_id", "month_year", "jobs_analyzed", "updated_at"}).
 			AddRow(userID, monthYear, testMonthlyQuotaLimit, time.Now())
 		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").
@@ -284,7 +285,7 @@ func TestService_CloudMode(t *testing.T) {
 		// Mock SetFirstAnalyzedAt
 		mockRepo.On("SetFirstAnalyzedAt", ctx, jobID).Return(nil).Once()
 
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 
 		// Begin transaction
 		mock.ExpectBegin()
@@ -314,7 +315,7 @@ func TestService_CloudMode(t *testing.T) {
 		// Mock SetFirstAnalyzedAt
 		mockRepo.On("SetFirstAnalyzedAt", ctx, jobID).Return(nil).Once()
 
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 
 		// Begin transaction
 		mock.ExpectBegin()
@@ -342,7 +343,7 @@ func TestService_CloudMode(t *testing.T) {
 		service := NewService(db, mockRepo, true) // Cloud mode enabled
 
 		// Mock GetMonthlyUsage query
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 		usedCount := 5
 		rows := sqlmock.NewRows([]string{"user_id", "month_year", "jobs_analyzed", "updated_at"}).
 			AddRow(userID, monthYear, usedCount, time.Now())
@@ -378,7 +379,7 @@ func TestService_CloudMode(t *testing.T) {
 		mockRepo.On("GetByID", adminCtx, userID, jobID).Return(job, nil).Once()
 
 		// Mock GetMonthlyUsage query - even if at limit
-		monthYear := getCurrentMonthYear()
+		monthYear := timeutil.GetCurrentMonthYear()
 		rows := sqlmock.NewRows([]string{"user_id", "month_year", "jobs_analyzed", "updated_at"}).
 			AddRow(userID, monthYear, testMonthlyQuotaLimit+10, time.Now()) // Over limit
 		mock.ExpectQuery("SELECT user_id, month_year, jobs_analyzed, updated_at FROM user_quota_usage").

--- a/internal/quota/unified_service.go
+++ b/internal/quota/unified_service.go
@@ -1,0 +1,108 @@
+package quota
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// UnifiedService provides a single interface for all quota operations
+type UnifiedService struct {
+	aiQuota     *Service
+	searchQuota *SearchQuotaService
+	repo        Repository
+}
+
+// NewUnifiedService creates a new unified quota service
+func NewUnifiedService(db *sql.DB, jobRepo JobRepository, isCloudMode bool) *UnifiedService {
+	repo := NewRepository(db)
+
+	return &UnifiedService{
+		aiQuota:     NewService(db, jobRepo, isCloudMode),
+		searchQuota: NewSearchQuotaService(repo, isCloudMode),
+		repo:        repo,
+	}
+}
+
+// CheckQuota checks any quota type
+func (s *UnifiedService) CheckQuota(ctx context.Context, userID int, quotaType string, metadata map[string]interface{}) (*QuotaCheckResult, error) {
+	switch quotaType {
+	case QuotaTypeAIAnalysis:
+		jobID, ok := metadata["job_id"].(int)
+		if !ok {
+			return nil, fmt.Errorf("job_id required for AI analysis quota check")
+		}
+		return s.aiQuota.CanAnalyzeJob(ctx, userID, jobID)
+
+	case QuotaTypeJobSearch:
+		return s.searchQuota.CanSearchJobs(ctx, userID)
+
+	case QuotaTypeSearchRuns:
+		return s.searchQuota.CanRunSearch(ctx, userID)
+
+	default:
+		return nil, fmt.Errorf("unknown quota type: %s", quotaType)
+	}
+}
+
+// RecordUsage records usage for any quota type
+func (s *UnifiedService) RecordUsage(ctx context.Context, userID int, quotaType string, metadata map[string]interface{}) error {
+	switch quotaType {
+	case QuotaTypeAIAnalysis:
+		jobID, ok := metadata["job_id"].(int)
+		if !ok {
+			return fmt.Errorf("job_id required for AI analysis recording")
+		}
+		return s.aiQuota.RecordAnalysis(ctx, userID, jobID)
+
+	case QuotaTypeJobSearch:
+		count, ok := metadata["count"].(int)
+		if !ok {
+			count = 1
+		}
+		return s.searchQuota.RecordJobsFound(ctx, userID, count)
+
+	case QuotaTypeSearchRuns:
+		return s.searchQuota.RecordSearchRun(ctx, userID)
+
+	default:
+		return fmt.Errorf("unknown quota type: %s", quotaType)
+	}
+}
+
+// GetAllQuotaStatus gets all quota statuses for a user
+func (s *UnifiedService) GetAllQuotaStatus(ctx context.Context, userID int) (interface{}, error) {
+	status := &UnifiedQuotaStatus{}
+
+	// Get AI analysis quota (monthly)
+	aiStatus, err := s.aiQuota.GetQuotaStatus(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AI quota status: %w", err)
+	}
+	status.AIAnalysis = *aiStatus
+
+	// Get job search quota (daily)
+	searchResult, err := s.searchQuota.GetStatus(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get job search quota status: %w", err)
+	}
+	status.JobSearch = searchResult.Status
+
+	// Get search runs quota (daily)
+	searchRunsResult, err := s.searchQuota.CanRunSearch(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get search runs quota status: %w", err)
+	}
+	status.SearchRuns = searchRunsResult.Status
+
+	return status, nil
+}
+
+// Expose underlying services for backward compatibility
+func (s *UnifiedService) AIQuotaService() *Service {
+	return s.aiQuota
+}
+
+func (s *UnifiedService) SearchQuotaService() *SearchQuotaService {
+	return s.searchQuota
+}

--- a/internal/quota/unified_service.go
+++ b/internal/quota/unified_service.go
@@ -89,7 +89,7 @@ func (s *UnifiedService) GetAllQuotaStatus(ctx context.Context, userID int) (int
 	status.JobSearch = searchResult.Status
 
 	// Get search runs quota (daily)
-	searchRunsResult, err := s.searchQuota.CanRunSearch(ctx, userID)
+	searchRunsResult, err := s.searchQuota.GetSearchRunStatus(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get search runs quota status: %w", err)
 	}

--- a/internal/settings/base.go
+++ b/internal/settings/base.go
@@ -162,7 +162,7 @@ func (h *BaseSettingsHandler) HandleCreate(c *gin.Context) {
 				"activeSettings":      "profile",
 				"pageTitle":           "Profile Settings",
 				"currentYear":         time.Now().Year(),
-				"securityPageEnabled": h.service.GetConfig().SecurityPageEnabled,
+				"securityPageEnabled": true, // Always enabled
 				"username":            username,
 				"profile":             profile,
 				fmt.Sprintf("isAdding%s", h.metadata.Name): true,

--- a/internal/settings/handlers.go
+++ b/internal/settings/handlers.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/benidevo/vega/internal/common/alerts"
 	"github.com/benidevo/vega/internal/common/render"
 	"github.com/benidevo/vega/internal/settings/models"
+	"github.com/benidevo/vega/internal/settings/services"
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 )
@@ -613,4 +615,221 @@ func (h *SettingsHandler) HandleUpdateCertificationForm(c *gin.Context) {
 // HandleDeleteCertification handles HTTP DELETE requests for removing a certification.
 func (h *SettingsHandler) HandleDeleteCertification(c *gin.Context) {
 	h.certificationHandler.HandleDelete(c)
+}
+
+// Job Search Preference Handlers
+
+// GetJobSearchPreferencesPage displays the job search preferences page
+func (h *SettingsHandler) GetJobSearchPreferencesPage(c *gin.Context) {
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		h.renderer.Error(c, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+	userID := userIDValue.(int)
+
+	preferences, err := h.service.GetUserPreferences(c.Request.Context(), userID)
+	if err != nil {
+		h.renderer.Error(c, http.StatusInternalServerError, "Failed to retrieve preferences")
+		return
+	}
+
+	// Pass MaxAge constants to template - using slice of structs to maintain order
+	type maxAgeOption struct {
+		Label    string
+		Value    int
+		Selected bool
+	}
+
+	maxAgeOptions := []maxAgeOption{
+		{"1 hour", models.MaxAgeOneHour, false},
+		{"6 hours", models.MaxAgeSixHours, false},
+		{"12 hours", models.MaxAgeTwelveHours, false},
+		{"1 day", models.MaxAgeOneDay, true},
+		{"3 days", models.MaxAgeThreeDays, false},
+		{"1 week", models.MaxAgeOneWeek, false},
+		{"2 weeks", models.MaxAgeTwoWeeks, false},
+		{"30 days", models.MaxAgeThirtyDays, false},
+	}
+
+	data := gin.H{
+		"title":          "Search Preferences",
+		"activeNav":      "search-preferences",
+		"page":           "settings-search-preferences",
+		"activeSettings": "search-preferences",
+		"pageTitle":      "Search Preferences",
+		"preferences":    preferences,
+		"maxAgeOptions":  maxAgeOptions,
+		"maxPreferences": services.MaxPreferencesPerUser,
+	}
+
+	h.renderer.HTML(c, http.StatusOK, "layouts/base.html", data)
+}
+
+// CreateJobSearchPreference handles creating a new job search preference
+func (h *SettingsHandler) CreateJobSearchPreference(c *gin.Context) {
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		c.HTML(http.StatusUnauthorized, "partials/alert.html", gin.H{
+			"type":    "error",
+			"context": "dashboard",
+			"message": "Unauthorized",
+		})
+		return
+	}
+	userID := userIDValue.(int)
+
+	// Parse form data manually to handle type conversions
+	jobTitle := strings.TrimSpace(c.PostForm("job_title"))
+	location := strings.TrimSpace(c.PostForm("location"))
+	skillsStr := strings.TrimSpace(c.PostForm("skills"))
+	maxAgeStr := c.PostForm("max_age")
+	isActiveStr := c.PostForm("is_active")
+
+	// Validate required fields
+	if jobTitle == "" || location == "" || maxAgeStr == "" {
+		c.HTML(http.StatusBadRequest, "partials/alert.html", gin.H{
+			"type":    "error",
+			"context": "dashboard",
+			"message": "Please fill in all required fields",
+		})
+		return
+	}
+
+	// Parse skills from comma-separated string
+	var skills []string
+	if skillsStr != "" {
+		skillsParts := strings.Split(skillsStr, ",")
+		for _, s := range skillsParts {
+			skill := strings.TrimSpace(s)
+			if skill != "" {
+				skills = append(skills, skill)
+			}
+		}
+	}
+
+	// Convert max_age to int
+	maxAge := 0
+	if _, err := fmt.Sscanf(maxAgeStr, "%d", &maxAge); err != nil {
+		c.HTML(http.StatusBadRequest, "partials/alert.html", gin.H{
+			"type":    "error",
+			"context": "dashboard",
+			"message": "Invalid maximum job age",
+		})
+		return
+	}
+
+	// Handle checkbox - if present it's checked, if not it's unchecked
+	isActive := isActiveStr == "on"
+
+	input := services.CreatePreferenceInput{
+		JobTitle: jobTitle,
+		Location: location,
+		Skills:   skills,
+		MaxAge:   maxAge,
+		IsActive: isActive,
+	}
+
+	_, err := h.service.CreatePreference(c.Request.Context(), userID, input)
+	if err != nil {
+		var message string
+		if err == services.ErrMaxPreferencesReached {
+			message = "Maximum number of preferences reached (4)"
+		} else if err == services.ErrInvalidPreferenceData {
+			message = "Invalid preference data. Please check your inputs."
+		} else {
+			message = "Failed to create preference"
+		}
+		c.HTML(http.StatusBadRequest, "partials/alert.html", gin.H{
+			"type":    "error",
+			"context": "dashboard",
+			"message": message,
+		})
+		return
+	}
+
+	// Redirect with success
+	c.Header("HX-Redirect", "/settings/search-preferences")
+	c.HTML(http.StatusOK, "partials/alert.html", gin.H{
+		"type":    "success",
+		"context": "dashboard",
+		"message": "Job search preference created successfully",
+	})
+}
+
+// UpdateJobSearchPreference handles updating an existing job search preference
+func (h *SettingsHandler) UpdateJobSearchPreference(c *gin.Context) {
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := userIDValue.(int)
+	preferenceID := c.Param("id")
+
+	var input services.UpdatePreferenceInput
+	if err := c.ShouldBindJSON(&input); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid input data"})
+		return
+	}
+
+	err := h.service.UpdatePreference(c.Request.Context(), userID, preferenceID, input)
+	if err != nil {
+		if err == services.ErrPreferenceNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Preference not found"})
+		} else if err == services.ErrInvalidPreferenceData {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid preference data"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update preference"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Preference updated successfully"})
+}
+
+// DeleteJobSearchPreference handles deleting a job search preference
+func (h *SettingsHandler) DeleteJobSearchPreference(c *gin.Context) {
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := userIDValue.(int)
+	preferenceID := c.Param("id")
+
+	err := h.service.DeletePreference(c.Request.Context(), userID, preferenceID)
+	if err != nil {
+		if err == services.ErrPreferenceNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Preference not found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete preference"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Preference deleted successfully"})
+}
+
+// ToggleJobSearchPreference handles toggling the active status of a preference
+func (h *SettingsHandler) ToggleJobSearchPreference(c *gin.Context) {
+	userIDValue, exists := c.Get("userID")
+	if !exists {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+	userID := userIDValue.(int)
+	preferenceID := c.Param("id")
+
+	err := h.service.TogglePreferenceStatus(c.Request.Context(), userID, preferenceID)
+	if err != nil {
+		if err == services.ErrPreferenceNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Preference not found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to toggle preference status"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Preference status toggled successfully"})
 }

--- a/internal/settings/interfaces/repository.go
+++ b/internal/settings/interfaces/repository.go
@@ -30,4 +30,13 @@ type SettingsRepository interface {
 	AddCertification(ctx context.Context, certification *models.Certification) error
 	UpdateCertification(ctx context.Context, certification *models.Certification) (*models.Certification, error)
 	DeleteCertification(ctx context.Context, id int, profileID int) error
+
+	// JobSearchPreference methods
+	CreateJobSearchPreference(ctx context.Context, userID int, preference *models.JobSearchPreference) error
+	GetJobSearchPreferenceByID(ctx context.Context, userID int, preferenceID string) (*models.JobSearchPreference, error)
+	GetJobSearchPreferencesByUserID(ctx context.Context, userID int) ([]*models.JobSearchPreference, error)
+	GetActiveJobSearchPreferencesByUserID(ctx context.Context, userID int) ([]*models.JobSearchPreference, error)
+	UpdateJobSearchPreference(ctx context.Context, userID int, preference *models.JobSearchPreference) error
+	DeleteJobSearchPreference(ctx context.Context, userID int, preferenceID string) error
+	ToggleJobSearchPreferenceActive(ctx context.Context, userID int, preferenceID string) error
 }

--- a/internal/settings/models/job_search_preference.go
+++ b/internal/settings/models/job_search_preference.go
@@ -1,0 +1,70 @@
+package models
+
+import (
+	"strings"
+	"time"
+)
+
+// MaxAge constants for job search preferences
+const (
+	MaxAgeOneHour     = 3600    // 1 hour in seconds
+	MaxAgeSixHours    = 21600   // 6 hours in seconds
+	MaxAgeTwelveHours = 43200   // 12 hours in seconds
+	MaxAgeOneDay      = 86400   // 1 day in seconds
+	MaxAgeThreeDays   = 259200  // 3 days in seconds
+	MaxAgeOneWeek     = 604800  // 1 week in seconds
+	MaxAgeTwoWeeks    = 1209600 // 2 weeks in seconds
+	MaxAgeThirtyDays  = 2592000 // 30 days in seconds
+
+	MinMaxAge = MaxAgeOneHour    // Minimum allowed max age
+	MaxMaxAge = MaxAgeThirtyDays // Maximum allowed max age
+)
+
+// JobSearchPreference represents a user's job search criteria
+type JobSearchPreference struct {
+	ID        string    `db:"id" json:"id"`
+	UserID    string    `db:"user_id" json:"user_id"`
+	JobTitle  string    `db:"job_title" json:"job_title" validate:"required,min=1,max=100"`
+	Location  string    `db:"location" json:"location" validate:"required,min=1,max=100"`
+	MaxAge    int       `db:"max_age" json:"max_age" validate:"required,min=3600,max=2592000"` // MinMaxAge to MaxMaxAge
+	IsActive  bool      `db:"is_active" json:"is_active"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt time.Time `db:"updated_at" json:"updated_at"`
+}
+
+// Sanitize cleans up the JobSearchPreference data
+func (j *JobSearchPreference) Sanitize() {
+	j.JobTitle = strings.TrimSpace(j.JobTitle)
+	j.Location = strings.TrimSpace(j.Location)
+}
+
+// Validate validates the JobSearchPreference struct
+func (j *JobSearchPreference) Validate() error {
+	return validate.Struct(j)
+}
+
+// GetMaxAgeDisplay returns a human-readable representation of MaxAge
+func (j *JobSearchPreference) GetMaxAgeDisplay() string {
+	switch j.MaxAge {
+	case MaxAgeOneHour:
+		return "1 hour"
+	case MaxAgeSixHours:
+		return "6 hours"
+	case MaxAgeTwelveHours:
+		return "12 hours"
+	case MaxAgeOneDay:
+		return "1 day"
+	case MaxAgeThreeDays:
+		return "3 days"
+	case MaxAgeOneWeek:
+		return "1 week"
+	case MaxAgeTwoWeeks:
+		return "2 weeks"
+	case MaxAgeThirtyDays:
+		return "30 days"
+	default:
+		// For any other value, calculate and display
+		duration := time.Duration(j.MaxAge) * time.Second
+		return duration.String()
+	}
+}

--- a/internal/settings/models/job_search_preference.go
+++ b/internal/settings/models/job_search_preference.go
@@ -23,9 +23,10 @@ const (
 // JobSearchPreference represents a user's job search criteria
 type JobSearchPreference struct {
 	ID        string    `db:"id" json:"id"`
-	UserID    string    `db:"user_id" json:"user_id"`
+	UserID    int       `db:"user_id" json:"user_id"`
 	JobTitle  string    `db:"job_title" json:"job_title" validate:"required,min=1,max=100"`
 	Location  string    `db:"location" json:"location" validate:"required,min=1,max=100"`
+	Skills    []string  `db:"skills" json:"skills,omitempty" validate:"max=10,dive,min=1,max=50"`
 	MaxAge    int       `db:"max_age" json:"max_age" validate:"required,min=3600,max=2592000"` // MinMaxAge to MaxMaxAge
 	IsActive  bool      `db:"is_active" json:"is_active"`
 	CreatedAt time.Time `db:"created_at" json:"created_at"`
@@ -36,6 +37,16 @@ type JobSearchPreference struct {
 func (j *JobSearchPreference) Sanitize() {
 	j.JobTitle = strings.TrimSpace(j.JobTitle)
 	j.Location = strings.TrimSpace(j.Location)
+
+	// Clean up skills
+	cleanedSkills := []string{}
+	for _, skill := range j.Skills {
+		trimmed := strings.TrimSpace(skill)
+		if trimmed != "" {
+			cleanedSkills = append(cleanedSkills, trimmed)
+		}
+	}
+	j.Skills = cleanedSkills
 }
 
 // Validate validates the JobSearchPreference struct

--- a/internal/settings/repository/job_search_preference.go
+++ b/internal/settings/repository/job_search_preference.go
@@ -1,0 +1,236 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"time"
+
+	"github.com/benidevo/vega/internal/settings/models"
+	"github.com/google/uuid"
+)
+
+// CreateJobSearchPreference creates a new job search preference
+func (r *ProfileRepository) CreateJobSearchPreference(ctx context.Context, userID int, preference *models.JobSearchPreference) error {
+	preference.ID = uuid.New().String()
+	preference.UserID = userID
+	preference.CreatedAt = time.Now()
+	preference.UpdatedAt = time.Now()
+
+	// Convert skills to JSON
+	var skillsJSON []byte
+	var err error
+	if len(preference.Skills) > 0 {
+		skillsJSON, err = json.Marshal(preference.Skills)
+		if err != nil {
+			return err
+		}
+	}
+
+	query := `
+		INSERT INTO job_search_preferences (
+			id, user_id, job_title, location, skills, max_age, is_active, created_at, updated_at
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+	_, err = r.db.ExecContext(ctx, query,
+		preference.ID, preference.UserID, preference.JobTitle, preference.Location,
+		skillsJSON, preference.MaxAge, preference.IsActive, preference.CreatedAt, preference.UpdatedAt,
+	)
+	return err
+}
+
+// GetJobSearchPreferenceByID retrieves a single job search preference by ID
+func (r *ProfileRepository) GetJobSearchPreferenceByID(ctx context.Context, userID int, preferenceID string) (*models.JobSearchPreference, error) {
+	query := `
+		SELECT id, user_id, job_title, location, skills, max_age, is_active, created_at, updated_at
+		FROM job_search_preferences
+		WHERE id = ? AND user_id = ?`
+
+	var preference models.JobSearchPreference
+	var skillsJSON sql.NullString
+
+	err := r.db.QueryRowContext(ctx, query, preferenceID, userID).Scan(
+		&preference.ID, &preference.UserID, &preference.JobTitle, &preference.Location,
+		&skillsJSON, &preference.MaxAge, &preference.IsActive, &preference.CreatedAt, &preference.UpdatedAt,
+	)
+
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	// Parse skills JSON
+	if skillsJSON.Valid && skillsJSON.String != "" {
+		if err := json.Unmarshal([]byte(skillsJSON.String), &preference.Skills); err != nil {
+			return nil, err
+		}
+	}
+
+	return &preference, nil
+}
+
+// GetJobSearchPreferencesByUserID retrieves all job search preferences for a user
+func (r *ProfileRepository) GetJobSearchPreferencesByUserID(ctx context.Context, userID int) ([]*models.JobSearchPreference, error) {
+	query := `
+		SELECT id, user_id, job_title, location, skills, max_age, is_active, created_at, updated_at
+		FROM job_search_preferences
+		WHERE user_id = ?
+		ORDER BY created_at DESC`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var preferences []*models.JobSearchPreference
+	for rows.Next() {
+		var preference models.JobSearchPreference
+		var skillsJSON sql.NullString
+
+		err := rows.Scan(
+			&preference.ID, &preference.UserID, &preference.JobTitle, &preference.Location,
+			&skillsJSON, &preference.MaxAge, &preference.IsActive, &preference.CreatedAt, &preference.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// Parse skills JSON
+		if skillsJSON.Valid && skillsJSON.String != "" {
+			if err := json.Unmarshal([]byte(skillsJSON.String), &preference.Skills); err != nil {
+				return nil, err
+			}
+		}
+
+		preferences = append(preferences, &preference)
+	}
+
+	return preferences, rows.Err()
+}
+
+// GetActiveJobSearchPreferencesByUserID retrieves only active job search preferences for a user
+func (r *ProfileRepository) GetActiveJobSearchPreferencesByUserID(ctx context.Context, userID int) ([]*models.JobSearchPreference, error) {
+	query := `
+		SELECT id, user_id, job_title, location, skills, max_age, is_active, created_at, updated_at
+		FROM job_search_preferences
+		WHERE user_id = ? AND is_active = true
+		ORDER BY created_at DESC`
+
+	rows, err := r.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var preferences []*models.JobSearchPreference
+	for rows.Next() {
+		var preference models.JobSearchPreference
+		var skillsJSON sql.NullString
+
+		err := rows.Scan(
+			&preference.ID, &preference.UserID, &preference.JobTitle, &preference.Location,
+			&skillsJSON, &preference.MaxAge, &preference.IsActive, &preference.CreatedAt, &preference.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		// Parse skills JSON
+		if skillsJSON.Valid && skillsJSON.String != "" {
+			if err := json.Unmarshal([]byte(skillsJSON.String), &preference.Skills); err != nil {
+				return nil, err
+			}
+		}
+
+		preferences = append(preferences, &preference)
+	}
+
+	return preferences, rows.Err()
+}
+
+// UpdateJobSearchPreference updates an existing job search preference
+func (r *ProfileRepository) UpdateJobSearchPreference(ctx context.Context, userID int, preference *models.JobSearchPreference) error {
+	preference.UpdatedAt = time.Now()
+
+	// Convert skills to JSON
+	var skillsJSON []byte
+	var err error
+	if len(preference.Skills) > 0 {
+		skillsJSON, err = json.Marshal(preference.Skills)
+		if err != nil {
+			return err
+		}
+	}
+
+	query := `
+		UPDATE job_search_preferences
+		SET job_title = ?, location = ?, skills = ?, max_age = ?, is_active = ?, updated_at = ?
+		WHERE id = ? AND user_id = ?`
+
+	result, err := r.db.ExecContext(ctx, query,
+		preference.JobTitle, preference.Location, skillsJSON, preference.MaxAge, preference.IsActive,
+		preference.UpdatedAt, preference.ID, userID,
+	)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}
+
+// DeleteJobSearchPreference deletes a job search preference
+func (r *ProfileRepository) DeleteJobSearchPreference(ctx context.Context, userID int, preferenceID string) error {
+	query := `DELETE FROM job_search_preferences WHERE id = ? AND user_id = ?`
+
+	result, err := r.db.ExecContext(ctx, query, preferenceID, userID)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}
+
+// ToggleJobSearchPreferenceActive toggles the active status of a job search preference
+func (r *ProfileRepository) ToggleJobSearchPreferenceActive(ctx context.Context, userID int, preferenceID string) error {
+	query := `
+		UPDATE job_search_preferences
+		SET is_active = NOT is_active, updated_at = ?
+		WHERE id = ? AND user_id = ?`
+
+	result, err := r.db.ExecContext(ctx, query, time.Now(), preferenceID, userID)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return sql.ErrNoRows
+	}
+
+	return nil
+}

--- a/internal/settings/routes.go
+++ b/internal/settings/routes.go
@@ -18,6 +18,7 @@ func RegisterRoutes(settingsGroup *gin.RouterGroup, handler *SettingsHandler) {
 
 	// Security settings
 	settingsGroup.GET("/security", handler.GetSecuritySettingsPage)
+	settingsGroup.POST("/security/account", handler.HandleUpdateSecurityAccount)
 
 	// Experience routes
 	settingsGroup.GET("/profile/experience/new", handler.GetAddExperiencePage)

--- a/internal/settings/routes.go
+++ b/internal/settings/routes.go
@@ -52,4 +52,7 @@ func RegisterRoutes(settingsGroup *gin.RouterGroup, handler *SettingsHandler) {
 	settingsGroup.PUT("/search-preferences/:id", handler.UpdateJobSearchPreference)
 	settingsGroup.DELETE("/search-preferences/:id", handler.DeleteJobSearchPreference)
 	settingsGroup.PATCH("/search-preferences/:id/toggle", handler.ToggleJobSearchPreference)
+
+	// Quota routes
+	settingsGroup.GET("/quotas", handler.GetQuotasPage)
 }

--- a/internal/settings/routes.go
+++ b/internal/settings/routes.go
@@ -45,4 +45,11 @@ func RegisterRoutes(settingsGroup *gin.RouterGroup, handler *SettingsHandler) {
 	// Support both methods for maximum compatibility
 	settingsGroup.DELETE("/profile/certification/:id", handler.HandleDeleteCertification)
 	settingsGroup.POST("/profile/certification/:id/delete", handler.HandleDeleteCertification)
+
+	// Job Search Preference routes
+	settingsGroup.GET("/search-preferences", handler.GetJobSearchPreferencesPage)
+	settingsGroup.POST("/search-preferences", handler.CreateJobSearchPreference)
+	settingsGroup.PUT("/search-preferences/:id", handler.UpdateJobSearchPreference)
+	settingsGroup.DELETE("/search-preferences/:id", handler.DeleteJobSearchPreference)
+	settingsGroup.PATCH("/search-preferences/:id/toggle", handler.ToggleJobSearchPreference)
 }

--- a/internal/settings/services.go
+++ b/internal/settings/services.go
@@ -21,16 +21,36 @@ type SettingsService struct {
 	cfg              *config.Settings
 	log              *logger.PrivacyLogger
 	centralValidator *services.CentralizedValidator
+	authService      AuthServiceInterface
+}
+
+// AuthServiceInterface defines the methods we need from the auth service
+type AuthServiceInterface interface {
+	ChangePassword(ctx context.Context, userID int, newPassword string) error
+	VerifyPassword(hashedPassword, password string) bool
 }
 
 // NewSettingsService creates a new SettingsService instance
-func NewSettingsService(settingsRepo interfaces.SettingsRepository, cfg *config.Settings, userRepo authrepo.UserRepository) *SettingsService {
+func NewSettingsService(settingsRepo interfaces.SettingsRepository, cfg *config.Settings, userRepo authrepo.UserRepository, authService AuthServiceInterface) *SettingsService {
 	return &SettingsService{
 		userRepo:         userRepo,
 		settingsRepo:     settingsRepo,
 		cfg:              cfg,
 		log:              logger.GetPrivacyLogger("settings"),
 		centralValidator: services.NewCentralizedValidator(),
+		authService:      authService,
+	}
+}
+
+// NewSettingsServiceForProfiles creates a settings service instance for profile management only (no auth required)
+func NewSettingsServiceForProfiles(settingsRepo interfaces.SettingsRepository, cfg *config.Settings, userRepo authrepo.UserRepository) *SettingsService {
+	return &SettingsService{
+		userRepo:         userRepo,
+		settingsRepo:     settingsRepo,
+		cfg:              cfg,
+		log:              logger.GetPrivacyLogger("settings"),
+		centralValidator: services.NewCentralizedValidator(),
+		authService:      nil, // No auth service needed for profile-only operations
 	}
 }
 

--- a/internal/settings/services.go
+++ b/internal/settings/services.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	authrepo "github.com/benidevo/vega/internal/auth/repository"
@@ -287,4 +288,140 @@ func (s *SettingsService) validateEntity(entity CRUDEntity) error {
 	default:
 		return fmt.Errorf("unsupported entity type for validation")
 	}
+}
+
+// Job Search Preference Methods
+
+// CreatePreference creates a new job search preference
+func (s *SettingsService) CreatePreference(ctx context.Context, userID int, input services.CreatePreferenceInput) (*models.JobSearchPreference, error) {
+	// Validate max age
+	if err := services.ValidateMaxAge(input.MaxAge); err != nil {
+		return nil, err
+	}
+
+	// Check if user has reached the maximum number of preferences
+	existingPrefs, err := s.settingsRepo.GetJobSearchPreferencesByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(existingPrefs) >= services.MaxPreferencesPerUser {
+		return nil, services.ErrMaxPreferencesReached
+	}
+
+	// Create the preference
+	preference := &models.JobSearchPreference{
+		JobTitle: input.JobTitle,
+		Location: input.Location,
+		Skills:   input.Skills,
+		MaxAge:   input.MaxAge,
+		IsActive: input.IsActive,
+	}
+
+	preference.Sanitize()
+	if err := preference.Validate(); err != nil {
+		return nil, err
+	}
+
+	if err := s.settingsRepo.CreateJobSearchPreference(ctx, userID, preference); err != nil {
+		return nil, err
+	}
+
+	return preference, nil
+}
+
+// GetUserPreferences retrieves all preferences for a user
+func (s *SettingsService) GetUserPreferences(ctx context.Context, userID int) ([]*models.JobSearchPreference, error) {
+	preferences, err := s.settingsRepo.GetJobSearchPreferencesByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return empty slice instead of nil for consistent API response
+	if preferences == nil {
+		return []*models.JobSearchPreference{}, nil
+	}
+
+	return preferences, nil
+}
+
+// GetActivePreferences retrieves only active preferences for a user
+func (s *SettingsService) GetActivePreferences(ctx context.Context, userID int) ([]*models.JobSearchPreference, error) {
+	preferences, err := s.settingsRepo.GetActiveJobSearchPreferencesByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Return empty slice instead of nil for consistent API response
+	if preferences == nil {
+		return []*models.JobSearchPreference{}, nil
+	}
+
+	return preferences, nil
+}
+
+// UpdatePreference updates an existing preference
+func (s *SettingsService) UpdatePreference(ctx context.Context, userID int, preferenceID string, input services.UpdatePreferenceInput) error {
+	// Validate max age
+	if err := services.ValidateMaxAge(input.MaxAge); err != nil {
+		return err
+	}
+
+	// Check if preference exists and belongs to user
+	existingPref, err := s.settingsRepo.GetJobSearchPreferenceByID(ctx, userID, preferenceID)
+	if err != nil {
+		return err
+	}
+	if existingPref == nil {
+		return services.ErrPreferenceNotFound
+	}
+
+	// Update the preference
+	preference := &models.JobSearchPreference{
+		ID:       preferenceID,
+		JobTitle: input.JobTitle,
+		Location: input.Location,
+		Skills:   input.Skills,
+		MaxAge:   input.MaxAge,
+		IsActive: input.IsActive,
+	}
+
+	preference.Sanitize()
+	if err := preference.Validate(); err != nil {
+		return err
+	}
+
+	err = s.settingsRepo.UpdateJobSearchPreference(ctx, userID, preference)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return services.ErrPreferenceNotFound
+		}
+		return err
+	}
+
+	return nil
+}
+
+// DeletePreference deletes a preference
+func (s *SettingsService) DeletePreference(ctx context.Context, userID int, preferenceID string) error {
+	err := s.settingsRepo.DeleteJobSearchPreference(ctx, userID, preferenceID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return services.ErrPreferenceNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// TogglePreferenceStatus toggles the active status of a preference
+func (s *SettingsService) TogglePreferenceStatus(ctx context.Context, userID int, preferenceID string) error {
+	err := s.settingsRepo.ToggleJobSearchPreferenceActive(ctx, userID, preferenceID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return services.ErrPreferenceNotFound
+		}
+		return err
+	}
+	return nil
 }

--- a/internal/settings/services/job_search_preference.go
+++ b/internal/settings/services/job_search_preference.go
@@ -1,0 +1,45 @@
+package services
+
+import (
+	"errors"
+
+	"github.com/benidevo/vega/internal/settings/models"
+)
+
+// Constants for service layer
+const (
+	MaxPreferencesPerUser = 4 // Limit to prevent abuse
+)
+
+// JobSearchPreferenceService errors
+var (
+	ErrPreferenceNotFound    = errors.New("job search preference not found")
+	ErrMaxPreferencesReached = errors.New("maximum number of preferences reached")
+	ErrInvalidPreferenceData = errors.New("invalid preference data")
+)
+
+// CreatePreferenceInput represents the input for creating a new preference
+type CreatePreferenceInput struct {
+	JobTitle string   `json:"job_title" form:"job_title" binding:"required,min=1,max=100"`
+	Location string   `json:"location" form:"location" binding:"required,min=1,max=100"`
+	Skills   []string `json:"skills,omitempty" form:"skills" binding:"max=10,dive,min=1,max=50"`
+	MaxAge   int      `json:"max_age" form:"max_age" binding:"required"`
+	IsActive bool     `json:"is_active" form:"is_active"`
+}
+
+// UpdatePreferenceInput represents the input for updating a preference
+type UpdatePreferenceInput struct {
+	JobTitle string   `json:"job_title" form:"job_title" binding:"required,min=1,max=100"`
+	Location string   `json:"location" form:"location" binding:"required,min=1,max=100"`
+	Skills   []string `json:"skills,omitempty" form:"skills" binding:"max=10,dive,min=1,max=50"`
+	MaxAge   int      `json:"max_age" form:"max_age" binding:"required"`
+	IsActive bool     `json:"is_active" form:"is_active"`
+}
+
+// ValidateMaxAge validates that the max age is within allowed bounds
+func ValidateMaxAge(maxAge int) error {
+	if maxAge < models.MinMaxAge || maxAge > models.MaxMaxAge {
+		return ErrInvalidPreferenceData
+	}
+	return nil
+}

--- a/internal/settings/services/job_search_preference_test.go
+++ b/internal/settings/services/job_search_preference_test.go
@@ -1,0 +1,422 @@
+package services_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/benidevo/vega/internal/settings/models"
+	"github.com/benidevo/vega/internal/settings/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Mock repository for testing
+type MockPreferenceRepository struct {
+	mock.Mock
+}
+
+func (m *MockPreferenceRepository) CreateJobSearchPreference(ctx context.Context, userID int, preference *models.JobSearchPreference) error {
+	args := m.Called(ctx, userID, preference)
+	return args.Error(0)
+}
+
+func (m *MockPreferenceRepository) GetJobSearchPreferencesByUserID(ctx context.Context, userID int) ([]*models.JobSearchPreference, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.JobSearchPreference), args.Error(1)
+}
+
+func (m *MockPreferenceRepository) GetJobSearchPreferenceByID(ctx context.Context, userID int, preferenceID string) (*models.JobSearchPreference, error) {
+	args := m.Called(ctx, userID, preferenceID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.JobSearchPreference), args.Error(1)
+}
+
+func (m *MockPreferenceRepository) UpdateJobSearchPreference(ctx context.Context, userID int, preference *models.JobSearchPreference) error {
+	args := m.Called(ctx, userID, preference)
+	return args.Error(0)
+}
+
+func (m *MockPreferenceRepository) DeleteJobSearchPreference(ctx context.Context, userID int, preferenceID string) error {
+	args := m.Called(ctx, userID, preferenceID)
+	return args.Error(0)
+}
+
+func (m *MockPreferenceRepository) ToggleJobSearchPreferenceActive(ctx context.Context, userID int, preferenceID string) error {
+	args := m.Called(ctx, userID, preferenceID)
+	return args.Error(0)
+}
+
+func (m *MockPreferenceRepository) GetActiveJobSearchPreferencesByUserID(ctx context.Context, userID int) ([]*models.JobSearchPreference, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*models.JobSearchPreference), args.Error(1)
+}
+
+// Implement remaining required methods as stubs
+func (m *MockPreferenceRepository) GetProfile(ctx context.Context, userID int) (*models.Profile, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) GetProfileWithRelated(ctx context.Context, userID int) (*models.Profile, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) UpdateProfile(ctx context.Context, profile *models.Profile) error {
+	return errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) CreateProfileIfNotExists(ctx context.Context, userID int) (*models.Profile, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) GetEntityByID(ctx context.Context, entityID, profileID int, entityType string) (interface{}, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) GetWorkExperiences(ctx context.Context, profileID int) ([]models.WorkExperience, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) AddWorkExperience(ctx context.Context, experience *models.WorkExperience) error {
+	return errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) UpdateWorkExperience(ctx context.Context, experience *models.WorkExperience) (*models.WorkExperience, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) DeleteWorkExperience(ctx context.Context, id int, profileID int) error {
+	return errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) DeleteAllWorkExperience(ctx context.Context, profileID int) error {
+	return errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) GetEducation(ctx context.Context, profileID int) ([]models.Education, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) AddEducation(ctx context.Context, education *models.Education) error {
+	return errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) UpdateEducation(ctx context.Context, education *models.Education) (*models.Education, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) DeleteEducation(ctx context.Context, id int, profileID int) error {
+	return errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) DeleteAllEducation(ctx context.Context, profileID int) error {
+	return errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) GetCertifications(ctx context.Context, profileID int) ([]models.Certification, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) AddCertification(ctx context.Context, certification *models.Certification) error {
+	return errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) UpdateCertification(ctx context.Context, certification *models.Certification) (*models.Certification, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (m *MockPreferenceRepository) DeleteCertification(ctx context.Context, id int, profileID int) error {
+	return errors.New("not implemented")
+}
+
+func TestCreatePreferenceInput_Validation(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      services.CreatePreferenceInput
+		wantMaxErr bool // Expecting max age error specifically
+	}{
+		{
+			name: "valid input",
+			input: services.CreatePreferenceInput{
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				MaxAge:   86400, // 1 day
+				IsActive: true,
+			},
+			wantMaxErr: false,
+		},
+		{
+			name: "max age too low",
+			input: services.CreatePreferenceInput{
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				MaxAge:   1800, // 30 minutes - below minimum
+				IsActive: true,
+			},
+			wantMaxErr: true,
+		},
+		{
+			name: "max age too high",
+			input: services.CreatePreferenceInput{
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				MaxAge:   9999999, // way above maximum
+				IsActive: true,
+			},
+			wantMaxErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := services.ValidateMaxAge(tt.input.MaxAge)
+			if tt.wantMaxErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestMaxPreferencesLimit(t *testing.T) {
+	// Test that the max preferences limit is enforced at 4
+	assert.Equal(t, 4, services.MaxPreferencesPerUser)
+}
+
+func TestValidateMaxAge(t *testing.T) {
+	tests := []struct {
+		name    string
+		maxAge  int
+		wantErr bool
+	}{
+		{"valid - 1 hour", models.MaxAgeOneHour, false},
+		{"valid - 6 hours", models.MaxAgeSixHours, false},
+		{"valid - 12 hours", models.MaxAgeTwelveHours, false},
+		{"valid - 1 day", models.MaxAgeOneDay, false},
+		{"valid - 3 days", models.MaxAgeThreeDays, false},
+		{"valid - 1 week", models.MaxAgeOneWeek, false},
+		{"valid - 2 weeks", models.MaxAgeTwoWeeks, false},
+		{"valid - 30 days", models.MaxAgeThirtyDays, false},
+		{"invalid - too low", 1800, true},     // 30 minutes
+		{"invalid - too high", 9999999, true}, // way too high
+		{"invalid - zero", 0, true},
+		{"invalid - negative", -3600, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := services.ValidateMaxAge(tt.maxAge)
+			if tt.wantErr {
+				assert.Equal(t, services.ErrInvalidPreferenceData, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestJobSearchPreference_GetMaxAgeDisplay(t *testing.T) {
+	tests := []struct {
+		name     string
+		maxAge   int
+		expected string
+	}{
+		{"1 hour", models.MaxAgeOneHour, "1 hour"},
+		{"6 hours", models.MaxAgeSixHours, "6 hours"},
+		{"12 hours", models.MaxAgeTwelveHours, "12 hours"},
+		{"1 day", models.MaxAgeOneDay, "1 day"},
+		{"3 days", models.MaxAgeThreeDays, "3 days"},
+		{"1 week", models.MaxAgeOneWeek, "1 week"},
+		{"2 weeks", models.MaxAgeTwoWeeks, "2 weeks"},
+		{"30 days", models.MaxAgeThirtyDays, "30 days"},
+		{"unknown value", 12345, "3h25m45s"}, // time.Duration format
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pref := &models.JobSearchPreference{
+				MaxAge: tt.maxAge,
+			}
+			assert.Equal(t, tt.expected, pref.GetMaxAgeDisplay())
+		})
+	}
+}
+
+func TestJobSearchPreference_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		pref    *models.JobSearchPreference
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid preference",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				MaxAge:   models.MaxAgeOneDay,
+				IsActive: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid preference with skills",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				Skills:   []string{"Go", "Python", "Docker"},
+				MaxAge:   models.MaxAgeOneDay,
+				IsActive: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing job title",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: "", // empty - will fail validation
+				Location: "Remote",
+				MaxAge:   models.MaxAgeOneDay,
+				IsActive: true,
+			},
+			wantErr: true,
+			errMsg:  "JobTitle",
+		},
+		{
+			name: "missing location",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: "Software Engineer",
+				Location: "", // empty - will fail validation
+				MaxAge:   models.MaxAgeOneDay,
+				IsActive: true,
+			},
+			wantErr: true,
+			errMsg:  "Location",
+		},
+		{
+			name: "job title too long",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: string(make([]byte, 101)), // 101 characters
+				Location: "Remote",
+				MaxAge:   models.MaxAgeOneDay,
+				IsActive: true,
+			},
+			wantErr: true,
+			errMsg:  "JobTitle",
+		},
+		{
+			name: "location too long",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: "Software Engineer",
+				Location: string(make([]byte, 101)), // 101 characters
+				MaxAge:   models.MaxAgeOneDay,
+				IsActive: true,
+			},
+			wantErr: true,
+			errMsg:  "Location",
+		},
+		{
+			name: "invalid max age - too low",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				MaxAge:   500, // too low
+				IsActive: true,
+			},
+			wantErr: true,
+			errMsg:  "MaxAge",
+		},
+		{
+			name: "too many skills",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				Skills:   []string{"Skill1", "Skill2", "Skill3", "Skill4", "Skill5", "Skill6", "Skill7", "Skill8", "Skill9", "Skill10", "Skill11"},
+				MaxAge:   models.MaxAgeOneDay,
+				IsActive: true,
+			},
+			wantErr: true,
+			errMsg:  "Skills",
+		},
+		{
+			name: "skill too long",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				Skills:   []string{"Go", "This is a really long skill name that exceeds the maximum allowed length of 50 characters"},
+				MaxAge:   models.MaxAgeOneDay,
+				IsActive: true,
+			},
+			wantErr: true,
+			errMsg:  "Skills",
+		},
+		{
+			name: "invalid max age - too high",
+			pref: &models.JobSearchPreference{
+				ID:       "test-id",
+				UserID:   1,
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				MaxAge:   9999999, // too high
+				IsActive: true,
+			},
+			wantErr: true,
+			errMsg:  "MaxAge",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.pref.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestJobSearchPreference_Sanitize(t *testing.T) {
+	pref := &models.JobSearchPreference{
+		JobTitle: "  Software Engineer  ",
+		Location: "  New York  ",
+		Skills:   []string{"  Go  ", "  Python  ", "", "  ", "Docker"},
+	}
+
+	pref.Sanitize()
+
+	assert.Equal(t, "Software Engineer", pref.JobTitle)
+	assert.Equal(t, "New York", pref.Location)
+	assert.Equal(t, []string{"Go", "Python", "Docker"}, pref.Skills)
+}

--- a/internal/settings/services_test.go
+++ b/internal/settings/services_test.go
@@ -151,6 +151,50 @@ func (m *MockProfileRepository) DeleteAllEducation(ctx context.Context, profileI
 	return args.Error(0)
 }
 
+func (m *MockProfileRepository) CreateJobSearchPreference(ctx context.Context, userID int, preference *settingsModels.JobSearchPreference) error {
+	args := m.Called(ctx, userID, preference)
+	return args.Error(0)
+}
+
+func (m *MockProfileRepository) GetJobSearchPreferenceByID(ctx context.Context, userID int, preferenceID string) (*settingsModels.JobSearchPreference, error) {
+	args := m.Called(ctx, userID, preferenceID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*settingsModels.JobSearchPreference), args.Error(1)
+}
+
+func (m *MockProfileRepository) GetJobSearchPreferencesByUserID(ctx context.Context, userID int) ([]*settingsModels.JobSearchPreference, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*settingsModels.JobSearchPreference), args.Error(1)
+}
+
+func (m *MockProfileRepository) GetActiveJobSearchPreferencesByUserID(ctx context.Context, userID int) ([]*settingsModels.JobSearchPreference, error) {
+	args := m.Called(ctx, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*settingsModels.JobSearchPreference), args.Error(1)
+}
+
+func (m *MockProfileRepository) UpdateJobSearchPreference(ctx context.Context, userID int, preference *settingsModels.JobSearchPreference) error {
+	args := m.Called(ctx, userID, preference)
+	return args.Error(0)
+}
+
+func (m *MockProfileRepository) DeleteJobSearchPreference(ctx context.Context, userID int, preferenceID string) error {
+	args := m.Called(ctx, userID, preferenceID)
+	return args.Error(0)
+}
+
+func (m *MockProfileRepository) ToggleJobSearchPreferenceActive(ctx context.Context, userID int, preferenceID string) error {
+	args := m.Called(ctx, userID, preferenceID)
+	return args.Error(0)
+}
+
 // MockUserRepository mocks the user repository
 type MockUserRepository struct {
 	mock.Mock
@@ -416,6 +460,144 @@ func TestDeleteAllEducation(t *testing.T) {
 		err := service.DeleteAllEducation(ctx, profileID)
 		assert.Error(t, err)
 		assert.Equal(t, repoErr, err)
+		mockProfileRepo.AssertExpectations(t)
+	})
+}
+
+func TestSettingsService_CreatePreference(t *testing.T) {
+	ctx := context.Background()
+	service, mockProfileRepo, _ := setupTestService()
+
+	t.Run("successful creation", func(t *testing.T) {
+		userID := 1
+		input := services.CreatePreferenceInput{
+			JobTitle: "Backend Engineer",
+			Location: "San Francisco",
+			Skills:   []string{"Go", "Kubernetes", "PostgreSQL"},
+			MaxAge:   settingsModels.MaxAgeOneWeek,
+			IsActive: true,
+		}
+
+		// Mock that user has no existing preferences
+		mockProfileRepo.On("GetJobSearchPreferencesByUserID", ctx, userID).
+			Return([]*settingsModels.JobSearchPreference{}, nil).Once()
+
+		mockProfileRepo.On("CreateJobSearchPreference", ctx, userID, mock.AnythingOfType("*models.JobSearchPreference")).
+			Run(func(args mock.Arguments) {
+				// Simulate what the real repository does
+				pref := args.Get(2).(*settingsModels.JobSearchPreference)
+				pref.ID = "generated-uuid"
+				pref.UserID = userID
+				pref.CreatedAt = time.Now()
+				pref.UpdatedAt = time.Now()
+			}).
+			Return(nil).Once()
+
+		pref, err := service.CreatePreference(ctx, userID, input)
+		require.NoError(t, err)
+		assert.NotNil(t, pref)
+		assert.Equal(t, input.JobTitle, pref.JobTitle)
+		assert.Equal(t, input.Location, pref.Location)
+		assert.Equal(t, input.Skills, pref.Skills)
+		assert.Equal(t, input.MaxAge, pref.MaxAge)
+		assert.Equal(t, input.IsActive, pref.IsActive)
+		assert.NotEmpty(t, pref.ID) // Should have generated UUID
+
+		mockProfileRepo.AssertExpectations(t)
+	})
+
+	t.Run("max preferences reached", func(t *testing.T) {
+		userID := 1
+		input := services.CreatePreferenceInput{
+			JobTitle: "Backend Engineer",
+			Location: "San Francisco",
+			MaxAge:   settingsModels.MaxAgeOneWeek,
+			IsActive: true,
+		}
+
+		// Mock that user already has 4 preferences (the limit)
+		existingPrefs := make([]*settingsModels.JobSearchPreference, services.MaxPreferencesPerUser)
+		for i := 0; i < services.MaxPreferencesPerUser; i++ {
+			existingPrefs[i] = &settingsModels.JobSearchPreference{ID: "test-id"}
+		}
+
+		mockProfileRepo.On("GetJobSearchPreferencesByUserID", ctx, userID).
+			Return(existingPrefs, nil).Once()
+
+		pref, err := service.CreatePreference(ctx, userID, input)
+		assert.Nil(t, pref)
+		assert.Equal(t, services.ErrMaxPreferencesReached, err)
+
+		mockProfileRepo.AssertExpectations(t)
+	})
+
+	t.Run("invalid max age", func(t *testing.T) {
+		userID := 1
+		input := services.CreatePreferenceInput{
+			JobTitle: "Backend Engineer",
+			Location: "San Francisco",
+			MaxAge:   100, // Too low
+			IsActive: true,
+		}
+
+		pref, err := service.CreatePreference(ctx, userID, input)
+		assert.Nil(t, pref)
+		assert.Equal(t, services.ErrInvalidPreferenceData, err)
+
+		mockProfileRepo.AssertNotCalled(t, "GetJobSearchPreferencesByUserID")
+	})
+}
+
+func TestSettingsService_GetUserPreferences(t *testing.T) {
+	ctx := context.Background()
+	service, mockProfileRepo, _ := setupTestService()
+
+	t.Run("successful retrieval", func(t *testing.T) {
+		userID := 1
+		expectedPrefs := []*settingsModels.JobSearchPreference{
+			{
+				ID:       "pref-1",
+				UserID:   userID,
+				JobTitle: "Software Engineer",
+				Location: "Remote",
+				MaxAge:   settingsModels.MaxAgeOneDay,
+				IsActive: true,
+			},
+			{
+				ID:       "pref-2",
+				UserID:   userID,
+				JobTitle: "Frontend Developer",
+				Location: "New York",
+				MaxAge:   settingsModels.MaxAgeOneWeek,
+				IsActive: false,
+			},
+		}
+
+		mockProfileRepo.On("GetJobSearchPreferencesByUserID", ctx, userID).
+			Return(expectedPrefs, nil).Once()
+
+		prefs, err := service.GetUserPreferences(ctx, userID)
+		require.NoError(t, err)
+		assert.Equal(t, expectedPrefs, prefs)
+
+		mockProfileRepo.AssertExpectations(t)
+	})
+}
+
+func TestSettingsService_DeletePreference(t *testing.T) {
+	ctx := context.Background()
+	service, mockProfileRepo, _ := setupTestService()
+
+	t.Run("successful deletion", func(t *testing.T) {
+		userID := 1
+		prefID := "test-pref-id"
+
+		mockProfileRepo.On("DeleteJobSearchPreference", ctx, userID, prefID).
+			Return(nil).Once()
+
+		err := service.DeletePreference(ctx, userID, prefID)
+		assert.NoError(t, err)
+
 		mockProfileRepo.AssertExpectations(t)
 	})
 }

--- a/internal/settings/setup.go
+++ b/internal/settings/setup.go
@@ -13,20 +13,20 @@ import (
 // Setup creates a new settings handler
 func Setup(cfg *config.Settings, db *sql.DB, aiService *ai.AIService, quotaService interface {
 	GetAllQuotaStatus(ctx context.Context, userID int) (interface{}, error)
-}) *SettingsHandler {
+}, authService AuthServiceInterface) *SettingsHandler {
 	userRepo := authrepo.NewSQLiteUserRepository(db)
 	settingsRepo := repository.NewProfileRepository(db)
-	service := NewSettingsService(settingsRepo, cfg, userRepo)
+	service := NewSettingsService(settingsRepo, cfg, userRepo, authService)
 	return NewSettingsHandler(service, aiService, quotaService)
 }
 
 // SetupWithService creates a new settings handler and returns both handler and service
 func SetupWithService(cfg *config.Settings, db *sql.DB, aiService *ai.AIService, quotaService interface {
 	GetAllQuotaStatus(ctx context.Context, userID int) (interface{}, error)
-}) (*SettingsHandler, *SettingsService) {
+}, authService AuthServiceInterface) (*SettingsHandler, *SettingsService) {
 	userRepo := authrepo.NewSQLiteUserRepository(db)
 	settingsRepo := repository.NewProfileRepository(db)
-	service := NewSettingsService(settingsRepo, cfg, userRepo)
+	service := NewSettingsService(settingsRepo, cfg, userRepo, authService)
 	handler := NewSettingsHandler(service, aiService, quotaService)
 	return handler, service
 }

--- a/internal/settings/setup.go
+++ b/internal/settings/setup.go
@@ -16,3 +16,12 @@ func Setup(cfg *config.Settings, db *sql.DB, aiService *ai.AIService) *SettingsH
 	service := NewSettingsService(settingsRepo, cfg, userRepo)
 	return NewSettingsHandler(service, aiService)
 }
+
+// SetupWithService creates a new settings handler and returns both handler and service
+func SetupWithService(cfg *config.Settings, db *sql.DB, aiService *ai.AIService) (*SettingsHandler, *SettingsService) {
+	userRepo := authrepo.NewSQLiteUserRepository(db)
+	settingsRepo := repository.NewProfileRepository(db)
+	service := NewSettingsService(settingsRepo, cfg, userRepo)
+	handler := NewSettingsHandler(service, aiService)
+	return handler, service
+}

--- a/internal/settings/setup.go
+++ b/internal/settings/setup.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"context"
 	"database/sql"
 
 	"github.com/benidevo/vega/internal/ai"
@@ -10,18 +11,22 @@ import (
 )
 
 // Setup creates a new settings handler
-func Setup(cfg *config.Settings, db *sql.DB, aiService *ai.AIService) *SettingsHandler {
+func Setup(cfg *config.Settings, db *sql.DB, aiService *ai.AIService, quotaService interface {
+	GetAllQuotaStatus(ctx context.Context, userID int) (interface{}, error)
+}) *SettingsHandler {
 	userRepo := authrepo.NewSQLiteUserRepository(db)
 	settingsRepo := repository.NewProfileRepository(db)
 	service := NewSettingsService(settingsRepo, cfg, userRepo)
-	return NewSettingsHandler(service, aiService)
+	return NewSettingsHandler(service, aiService, quotaService)
 }
 
 // SetupWithService creates a new settings handler and returns both handler and service
-func SetupWithService(cfg *config.Settings, db *sql.DB, aiService *ai.AIService) (*SettingsHandler, *SettingsService) {
+func SetupWithService(cfg *config.Settings, db *sql.DB, aiService *ai.AIService, quotaService interface {
+	GetAllQuotaStatus(ctx context.Context, userID int) (interface{}, error)
+}) (*SettingsHandler, *SettingsService) {
 	userRepo := authrepo.NewSQLiteUserRepository(db)
 	settingsRepo := repository.NewProfileRepository(db)
 	service := NewSettingsService(settingsRepo, cfg, userRepo)
-	handler := NewSettingsHandler(service, aiService)
+	handler := NewSettingsHandler(service, aiService, quotaService)
 	return handler, service
 }

--- a/internal/vega/app.go
+++ b/internal/vega/app.go
@@ -97,9 +97,18 @@ func (a *App) Run() error {
 	signal.Notify(a.done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
-		log.Printf("Starting server on %s\n", a.config.ServerPort)
+		log.Info().Str("port", a.config.ServerPort).Msg("Starting server")
+
+		if !a.config.IsCloudMode {
+			log.Info().Msgf("🚀 Vega AI is running at http://localhost%s", a.config.ServerPort)
+			log.Info().Msg("📋 Default login: Username 'admin', Password 'VegaAdmin'")
+			log.Info().Msgf("🔒 Change your password at http://localhost%s/settings/security", a.config.ServerPort)
+		} else {
+			log.Info().Str("port", a.config.ServerPort).Msg("🚀 Vega AI is running in cloud mode")
+		}
+
 		if err := a.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Printf("Error starting server: %v\n", err)
+			log.Error().Err(err).Msg("Error starting server")
 		}
 	}()
 

--- a/internal/vega/routes.go
+++ b/internal/vega/routes.go
@@ -34,7 +34,7 @@ func SetupRoutes(a *App) {
 		aiService = nil
 	}
 
-	authHandler := auth.SetupAuth(a.db, &a.config)
+	authHandler, authService := auth.SetupAuthWithService(a.db, &a.config)
 	jobService := job.SetupService(a.db, &a.config, a.cache)
 	jobHandler := job.NewJobHandler(jobService, &a.config)
 
@@ -43,7 +43,7 @@ func SetupRoutes(a *App) {
 	quotaAdapter := quota.NewJobRepositoryAdapter(jobRepo)
 	unifiedQuotaService := quota.NewUnifiedService(a.db, quotaAdapter, a.config.IsCloudMode)
 
-	settingsHandler, settingsService := settings.SetupWithService(&a.config, a.db, aiService, unifiedQuotaService)
+	settingsHandler, settingsService := settings.SetupWithService(&a.config, a.db, aiService, unifiedQuotaService, authService)
 	authAPIHandler := authapi.Setup(a.db, &a.config)
 	jobAPIHandler := jobapi.Setup(a.db, &a.config, a.cache)
 

--- a/migrations/sqlite/000004_add_job_search_preferences.down.sql
+++ b/migrations/sqlite/000004_add_job_search_preferences.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_job_search_preferences_active;
+DROP INDEX IF EXISTS idx_job_search_preferences_user_id;
+DROP TABLE IF EXISTS job_search_preferences;

--- a/migrations/sqlite/000004_add_job_search_preferences.up.sql
+++ b/migrations/sqlite/000004_add_job_search_preferences.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE job_search_preferences (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    job_title TEXT NOT NULL,
+    location TEXT NOT NULL,
+    max_age INTEGER NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_job_search_preferences_user_id ON job_search_preferences(user_id);
+CREATE INDEX idx_job_search_preferences_active ON job_search_preferences(user_id, is_active);

--- a/migrations/sqlite/000004_add_job_search_preferences.up.sql
+++ b/migrations/sqlite/000004_add_job_search_preferences.up.sql
@@ -1,8 +1,9 @@
 CREATE TABLE job_search_preferences (
     id TEXT PRIMARY KEY,
-    user_id TEXT NOT NULL,
+    user_id INTEGER NOT NULL,
     job_title TEXT NOT NULL,
     location TEXT NOT NULL,
+    skills JSON,
     max_age INTEGER NOT NULL,
     is_active BOOLEAN NOT NULL DEFAULT true,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/migrations/sqlite/000005_add_search_quotas.down.sql
+++ b/migrations/sqlite/000005_add_search_quotas.down.sql
@@ -1,0 +1,2 @@
+-- Drop daily quotas table
+DROP TABLE IF EXISTS user_daily_quotas;

--- a/migrations/sqlite/000005_add_search_quotas.up.sql
+++ b/migrations/sqlite/000005_add_search_quotas.up.sql
@@ -1,0 +1,13 @@
+-- Create table for tracking daily quotas
+CREATE TABLE user_daily_quotas (
+    user_id INTEGER NOT NULL,
+    date TEXT NOT NULL,          -- Format: "2006-01-02"
+    quota_key TEXT NOT NULL,     -- 'jobs_found', 'searches_run'
+    value INTEGER DEFAULT 0,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, date, quota_key),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Index for efficient lookups
+CREATE INDEX idx_user_daily_quotas_lookup ON user_daily_quotas(user_id, date);

--- a/migrations/sqlite/000006_add_quota_configs.down.sql
+++ b/migrations/sqlite/000006_add_quota_configs.down.sql
@@ -1,0 +1,2 @@
+-- Drop quota configs table
+DROP TABLE IF EXISTS quota_configs;

--- a/migrations/sqlite/000006_add_quota_configs.up.sql
+++ b/migrations/sqlite/000006_add_quota_configs.up.sql
@@ -1,0 +1,14 @@
+-- Add quota configuration table for dynamic quota limits
+CREATE TABLE quota_configs (
+    quota_type TEXT PRIMARY KEY,
+    free_limit INTEGER NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Seed with default quota values
+INSERT INTO quota_configs (quota_type, free_limit, description) VALUES
+('ai_analysis_monthly', 5, 'AI job analysis per month'),
+('job_search_daily', 100, 'Job search results per day'),
+('search_runs_daily', 20, 'Search runs per day');

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -284,6 +284,14 @@
       </div>
       {{template "footer" .}}
     </div>
+  {{else if eq .page "settings-search-preferences" }}
+    <!-- Settings search preferences page -->
+    <div class="min-h-screen bg-slate-900 flex flex-col">
+      <div class="flex-1">
+        {{template "settings-layout" .}}
+      </div>
+      {{template "footer" .}}
+    </div>
   {{else}}
     <!-- Modern layout with enhanced backgrounds for home and login pages -->
     <div class="{{if eq .page "login"}}h-screen overflow-hidden{{else}}min-h-screen{{end}} flex {{if eq .page "home"}}flex-col{{end}} items-center justify-center relative overflow-hidden">
@@ -600,6 +608,9 @@
   <script src="/static/js/skills-management.js"></script>
   <script src="/static/js/cv-upload.js"></script>
   <script src="/static/js/profile-scroll.js"></script>
+  {{end}}
+  {{if eq .page "settings-search-preferences"}}
+  <script src="/static/js/skills-management.js"></script>
   {{end}}
 </body>
 </html>

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -292,6 +292,14 @@
       </div>
       {{template "footer" .}}
     </div>
+  {{else if eq .page "settings-quotas" }}
+    <!-- Settings quotas page -->
+    <div class="min-h-screen bg-slate-900 flex flex-col">
+      <div class="flex-1">
+        {{template "settings-layout" .}}
+      </div>
+      {{template "footer" .}}
+    </div>
   {{else}}
     <!-- Modern layout with enhanced backgrounds for home and login pages -->
     <div class="{{if eq .page "login"}}h-screen overflow-hidden{{else}}min-h-screen{{end}} flex {{if eq .page "home"}}flex-col{{end}} items-center justify-center relative overflow-hidden">

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -51,6 +51,13 @@
         Search Preferences
       </a>
 
+      <a href="/settings/quotas" class="{{if eq .activeNav "quotas"}}bg-slate-700 text-white{{else}}text-gray-300 hover:bg-slate-700 hover:text-white{{end}} group flex items-center px-3 py-2.5 text-sm font-medium rounded-md">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3 {{if eq .activeNav "quotas"}}text-primary{{else}}text-gray-400 group-hover:text-primary{{end}}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+        </svg>
+        Usage & Quotas
+      </a>
+
       {{if .securityPageEnabled}}
       <a href="/settings/security" class="{{if eq .activeNav "security"}}bg-slate-700 text-white{{else}}text-gray-300 hover:bg-slate-700 hover:text-white{{end}} group flex items-center px-3 py-2.5 text-sm font-medium rounded-md">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3 {{if eq .activeNav "security"}}text-primary{{else}}text-gray-400 group-hover:text-primary{{end}}" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/templates/partials/sidebar.html
+++ b/templates/partials/sidebar.html
@@ -44,6 +44,13 @@
         Profile
       </a>
 
+      <a href="/settings/search-preferences" class="{{if eq .activeNav "search-preferences"}}bg-slate-700 text-white{{else}}text-gray-300 hover:bg-slate-700 hover:text-white{{end}} group flex items-center px-3 py-2.5 text-sm font-medium rounded-md">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3 {{if eq .activeNav "search-preferences"}}text-primary{{else}}text-gray-400 group-hover:text-primary{{end}}" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+        </svg>
+        Search Preferences
+      </a>
+
       {{if .securityPageEnabled}}
       <a href="/settings/security" class="{{if eq .activeNav "security"}}bg-slate-700 text-white{{else}}text-gray-300 hover:bg-slate-700 hover:text-white{{end}} group flex items-center px-3 py-2.5 text-sm font-medium rounded-md">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 mr-3 {{if eq .activeNav "security"}}text-primary{{else}}text-gray-400 group-hover:text-primary{{end}}" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/templates/settings/settings_layout.html
+++ b/templates/settings/settings_layout.html
@@ -21,6 +21,8 @@
         {{template "settings-profile-content" .}}
       {{else if eq .page "settings-security"}}
         {{template "settings-security-content" .}}
+      {{else if eq .page "settings-search-preferences"}}
+        {{template "settings-search-preferences-content" .}}
       {{else}}
         <!-- Fallback content if no specific template is defined -->
         <div class="text-center py-8">

--- a/templates/settings/settings_layout.html
+++ b/templates/settings/settings_layout.html
@@ -23,6 +23,8 @@
         {{template "settings-security-content" .}}
       {{else if eq .page "settings-search-preferences"}}
         {{template "settings-search-preferences-content" .}}
+      {{else if eq .page "settings-quotas"}}
+        {{template "settings-quotas-content" .}}
       {{else}}
         <!-- Fallback content if no specific template is defined -->
         <div class="text-center py-8">

--- a/templates/settings/settings_quotas.html
+++ b/templates/settings/settings_quotas.html
@@ -49,13 +49,11 @@
           {{else}}
           <p class="text-xs text-gray-400">Unlimited</p>
           {{end}}
+          {{if and (ne .quotaStatus.JobSearch.Limit -1) (not .quotaStatus.JobSearch.ResetDate.IsZero)}}
           <p class="text-xs text-gray-500 mt-2">
-            {{if and (ne .quotaStatus.JobSearch.Limit -1) (not .quotaStatus.JobSearch.ResetDate.IsZero)}}
-              Resets {{.quotaStatus.JobSearch.ResetDate.Format "Jan 2, 3:04 PM"}}
-            {{else}}
-              No reset - unlimited usage
-            {{end}}
+            Resets {{.quotaStatus.JobSearch.ResetDate.Format "Jan 2, 3:04 PM"}}
           </p>
+          {{end}}
         </div>
 
         <!-- Search Runs Today -->
@@ -83,13 +81,11 @@
           {{else}}
           <p class="text-xs text-gray-400">Unlimited</p>
           {{end}}
+          {{if and (ne .quotaStatus.SearchRuns.Limit -1) (not .quotaStatus.SearchRuns.ResetDate.IsZero)}}
           <p class="text-xs text-gray-500 mt-2">
-            {{if and (ne .quotaStatus.SearchRuns.Limit -1) (not .quotaStatus.SearchRuns.ResetDate.IsZero)}}
-              Resets {{.quotaStatus.SearchRuns.ResetDate.Format "Jan 2, 3:04 PM"}}
-            {{else}}
-              No reset - unlimited usage
-            {{end}}
+            Resets {{.quotaStatus.SearchRuns.ResetDate.Format "Jan 2, 3:04 PM"}}
           </p>
+          {{end}}
         </div>
 
         <!-- AI Analyses This Month -->
@@ -117,13 +113,11 @@
           {{else}}
           <p class="text-xs text-gray-400">Unlimited</p>
           {{end}}
+          {{if and (ne .quotaStatus.AIAnalysis.Limit -1) (not .quotaStatus.AIAnalysis.ResetDate.IsZero)}}
           <p class="text-xs text-gray-500 mt-2">
-            {{if and (ne .quotaStatus.AIAnalysis.Limit -1) (not .quotaStatus.AIAnalysis.ResetDate.IsZero)}}
-              Resets {{.quotaStatus.AIAnalysis.ResetDate.Format "Jan 2, 2006"}}
-            {{else}}
-              No reset - unlimited usage
-            {{end}}
+            Resets {{.quotaStatus.AIAnalysis.ResetDate.Format "Jan 2, 2006"}}
           </p>
+          {{end}}
         </div>
       </div>
     </div>
@@ -266,9 +260,13 @@
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
           </svg>
           <div>
-            <h4 class="text-sm font-medium text-primary mb-1">Need More?</h4>
+            <h4 class="text-sm font-medium text-primary mb-1">Need Higher Limits?</h4>
             <p class="text-xs md:text-sm text-gray-300">
-              Premium plans with higher limits are coming soon. Stay tuned for updates!
+              You can create a self-hosted version with unlimited usage. Visit 
+              <a href="https://vega.benidevo.com" target="_blank" rel="noopener noreferrer" class="text-primary hover:text-primary-light underline">
+                vega.benidevo.com
+              </a> 
+              for instructions on how to get started.
             </p>
           </div>
         </div>

--- a/templates/settings/settings_quotas.html
+++ b/templates/settings/settings_quotas.html
@@ -1,0 +1,321 @@
+{{define "settings-quotas-content"}}
+<div class="mx-0 md:max-w-6xl md:mx-auto relative">
+  <!-- Alert container for any notifications -->
+  <div id="form-alert-container" class="mb-4 md:mb-6 px-4 md:px-0" hx-swap-oob="true" aria-live="polite"></div>
+  
+  <!-- Content container with responsive padding -->
+  <div class="relative p-4 md:p-6 bg-slate-800 bg-opacity-70 backdrop-blur-xl rounded-none md:rounded-xl shadow-2xl border-0 md:border border-white border-opacity-10">
+    
+    <!-- Page Header -->
+    <div class="mb-6 pb-6 border-b border-slate-700 border-opacity-50">
+      <h2 class="text-xl md:text-2xl font-bold text-white mb-2">Usage & Quotas</h2>
+      <p class="text-sm md:text-base text-gray-400">
+        {{if .isCloudMode}}
+          Monitor your usage and quota limits for all features.
+        {{else}}
+          Your self-hosted instance has unlimited usage for all features.
+        {{end}}
+      </p>
+    </div>
+
+    {{if .hasQuotaData}}
+    <!-- Current Usage Section -->
+    <div class="mb-8">
+      <h3 class="text-lg md:text-xl font-semibold mb-4 text-white">Current Usage</h3>
+      
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 md:gap-4 lg:gap-6">
+        <!-- Jobs Found Today -->
+        <div class="bg-slate-700 bg-opacity-50 rounded-lg p-4 md:p-5 lg:p-6 hover:bg-opacity-70 transition-all duration-200">
+          <div class="flex items-center justify-between mb-2 md:mb-3">
+            <h4 class="text-sm md:text-base font-medium text-white">Jobs Found Today</h4>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 md:h-6 w-5 md:w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+          </div>
+          <p class="text-xl md:text-2xl font-bold text-white mb-2">
+            {{if eq .quotaStatus.JobSearch.Limit -1}}{{.quotaStatus.JobSearch.Used}}{{else}}{{.quotaStatus.JobSearch.Used}} / {{.quotaStatus.JobSearch.Limit}}{{end}}
+          </p>
+          {{if ne .quotaStatus.JobSearch.Limit -1}}
+          <div class="w-full bg-slate-600 rounded-full h-2 mb-2">
+            <div class="bg-primary h-2 rounded-full transition-all duration-300" data-used="{{.quotaStatus.JobSearch.Used}}" data-limit="{{.quotaStatus.JobSearch.Limit}}"></div>
+          </div>
+          <p class="text-xs text-gray-400">
+            {{if eq .quotaStatus.JobSearch.Used .quotaStatus.JobSearch.Limit}}
+              Limit reached
+            {{else}}
+              {{sub .quotaStatus.JobSearch.Limit .quotaStatus.JobSearch.Used}} remaining
+            {{end}}
+          </p>
+          {{else}}
+          <p class="text-xs text-gray-400">Unlimited</p>
+          {{end}}
+          <p class="text-xs text-gray-500 mt-2">
+            {{if and (ne .quotaStatus.JobSearch.Limit -1) (not .quotaStatus.JobSearch.ResetDate.IsZero)}}
+              Resets {{.quotaStatus.JobSearch.ResetDate.Format "Jan 2, 3:04 PM"}}
+            {{else}}
+              No reset - unlimited usage
+            {{end}}
+          </p>
+        </div>
+
+        <!-- Search Runs Today -->
+        <div class="bg-slate-700 bg-opacity-50 rounded-lg p-4 md:p-5 lg:p-6 hover:bg-opacity-70 transition-all duration-200">
+          <div class="flex items-center justify-between mb-2 md:mb-3">
+            <h4 class="text-sm md:text-base font-medium text-white">Search Runs Today</h4>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 md:h-6 w-5 md:w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
+            </svg>
+          </div>
+          <p class="text-xl md:text-2xl font-bold text-white mb-2">
+            {{if eq .quotaStatus.SearchRuns.Limit -1}}{{.quotaStatus.SearchRuns.Used}}{{else}}{{.quotaStatus.SearchRuns.Used}} / {{.quotaStatus.SearchRuns.Limit}}{{end}}
+          </p>
+          {{if ne .quotaStatus.SearchRuns.Limit -1}}
+          <div class="w-full bg-slate-600 rounded-full h-2 mb-2">
+            <div class="bg-primary h-2 rounded-full transition-all duration-300" data-used="{{.quotaStatus.SearchRuns.Used}}" data-limit="{{.quotaStatus.SearchRuns.Limit}}"></div>
+          </div>
+          <p class="text-xs text-gray-400">
+            {{if eq .quotaStatus.SearchRuns.Used .quotaStatus.SearchRuns.Limit}}
+              Limit reached
+            {{else}}
+              {{sub .quotaStatus.SearchRuns.Limit .quotaStatus.SearchRuns.Used}} remaining
+            {{end}}
+          </p>
+          {{else}}
+          <p class="text-xs text-gray-400">Unlimited</p>
+          {{end}}
+          <p class="text-xs text-gray-500 mt-2">
+            {{if and (ne .quotaStatus.SearchRuns.Limit -1) (not .quotaStatus.SearchRuns.ResetDate.IsZero)}}
+              Resets {{.quotaStatus.SearchRuns.ResetDate.Format "Jan 2, 3:04 PM"}}
+            {{else}}
+              No reset - unlimited usage
+            {{end}}
+          </p>
+        </div>
+
+        <!-- AI Analyses This Month -->
+        <div class="bg-slate-700 bg-opacity-50 rounded-lg p-4 md:p-5 lg:p-6 hover:bg-opacity-70 transition-all duration-200">
+          <div class="flex items-center justify-between mb-2 md:mb-3">
+            <h4 class="text-sm md:text-base font-medium text-white">AI Analyses This Month</h4>
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 md:h-6 w-5 md:w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+            </svg>
+          </div>
+          <p class="text-xl md:text-2xl font-bold text-white mb-2">
+            {{if eq .quotaStatus.AIAnalysis.Limit -1}}{{.quotaStatus.AIAnalysis.Used}}{{else}}{{.quotaStatus.AIAnalysis.Used}} / {{.quotaStatus.AIAnalysis.Limit}}{{end}}
+          </p>
+          {{if ne .quotaStatus.AIAnalysis.Limit -1}}
+          <div class="w-full bg-slate-600 rounded-full h-2 mb-2">
+            <div class="bg-primary h-2 rounded-full transition-all duration-300" data-used="{{.quotaStatus.AIAnalysis.Used}}" data-limit="{{.quotaStatus.AIAnalysis.Limit}}"></div>
+          </div>
+          <p class="text-xs text-gray-400">
+            {{if eq .quotaStatus.AIAnalysis.Used .quotaStatus.AIAnalysis.Limit}}
+              Limit reached
+            {{else}}
+              {{sub .quotaStatus.AIAnalysis.Limit .quotaStatus.AIAnalysis.Used}} remaining
+            {{end}}
+          </p>
+          {{else}}
+          <p class="text-xs text-gray-400">Unlimited</p>
+          {{end}}
+          <p class="text-xs text-gray-500 mt-2">
+            {{if and (ne .quotaStatus.AIAnalysis.Limit -1) (not .quotaStatus.AIAnalysis.ResetDate.IsZero)}}
+              Resets {{.quotaStatus.AIAnalysis.ResetDate.Format "Jan 2, 2006"}}
+            {{else}}
+              No reset - unlimited usage
+            {{end}}
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Quota Details Section -->
+    <div class="mb-8">
+      <h3 class="text-lg md:text-xl font-semibold mb-4 text-white">Quota Details</h3>
+      
+      <!-- Desktop Table View -->
+      <div class="hidden md:block bg-slate-700 bg-opacity-50 rounded-lg overflow-hidden">
+        <table class="w-full">
+          <thead>
+            <tr class="border-b border-slate-600">
+              <th class="text-left px-4 py-3 text-sm font-medium text-gray-300">Feature</th>
+              <th class="text-center px-4 py-3 text-sm font-medium text-gray-300">Period</th>
+              <th class="text-center px-4 py-3 text-sm font-medium text-gray-300">Free Limit</th>
+              <th class="text-center px-4 py-3 text-sm font-medium text-gray-300">Your Limit</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="border-b border-slate-600 hover:bg-slate-600 hover:bg-opacity-30 transition-colors">
+              <td class="px-4 py-3 text-sm text-gray-300">Job Search Results</td>
+              <td class="text-center px-4 py-3 text-sm text-gray-400">Daily</td>
+              <td class="text-center px-4 py-3 text-sm text-gray-400">100</td>
+              <td class="text-center px-4 py-3 text-sm font-medium text-white">
+                {{if eq .quotaStatus.JobSearch.Limit -1}}Unlimited{{else}}{{.quotaStatus.JobSearch.Limit}}{{end}}
+              </td>
+            </tr>
+            <tr class="border-b border-slate-600 hover:bg-slate-600 hover:bg-opacity-30 transition-colors">
+              <td class="px-4 py-3 text-sm text-gray-300">Search Runs</td>
+              <td class="text-center px-4 py-3 text-sm text-gray-400">Daily</td>
+              <td class="text-center px-4 py-3 text-sm text-gray-400">20</td>
+              <td class="text-center px-4 py-3 text-sm font-medium text-white">
+                {{if eq .quotaStatus.SearchRuns.Limit -1}}Unlimited{{else}}{{.quotaStatus.SearchRuns.Limit}}{{end}}
+              </td>
+            </tr>
+            <tr class="hover:bg-slate-600 hover:bg-opacity-30 transition-colors">
+              <td class="px-4 py-3 text-sm text-gray-300">AI Job Analysis</td>
+              <td class="text-center px-4 py-3 text-sm text-gray-400">Monthly</td>
+              <td class="text-center px-4 py-3 text-sm text-gray-400">5</td>
+              <td class="text-center px-4 py-3 text-sm font-medium text-white">
+                {{if eq .quotaStatus.AIAnalysis.Limit -1}}Unlimited{{else}}{{.quotaStatus.AIAnalysis.Limit}}{{end}}
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Mobile Card View -->
+      <div class="md:hidden space-y-3">
+        <!-- Job Search Results Card -->
+        <div class="bg-slate-700 bg-opacity-50 rounded-lg p-4">
+          <h4 class="font-medium text-white mb-2">Job Search Results</h4>
+          <div class="grid grid-cols-2 gap-2 text-sm">
+            <div>
+              <span class="text-gray-400">Period:</span>
+              <span class="ml-2 text-gray-300">Daily</span>
+            </div>
+            <div>
+              <span class="text-gray-400">Free:</span>
+              <span class="ml-2 text-gray-300">100</span>
+            </div>
+            <div class="col-span-2">
+              <span class="text-gray-400">Your Limit:</span>
+              <span class="ml-2 font-medium text-white">
+                {{if eq .quotaStatus.JobSearch.Limit -1}}Unlimited{{else}}{{.quotaStatus.JobSearch.Limit}}{{end}}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Search Runs Card -->
+        <div class="bg-slate-700 bg-opacity-50 rounded-lg p-4">
+          <h4 class="font-medium text-white mb-2">Search Runs</h4>
+          <div class="grid grid-cols-2 gap-2 text-sm">
+            <div>
+              <span class="text-gray-400">Period:</span>
+              <span class="ml-2 text-gray-300">Daily</span>
+            </div>
+            <div>
+              <span class="text-gray-400">Free:</span>
+              <span class="ml-2 text-gray-300">20</span>
+            </div>
+            <div class="col-span-2">
+              <span class="text-gray-400">Your Limit:</span>
+              <span class="ml-2 font-medium text-white">
+                {{if eq .quotaStatus.SearchRuns.Limit -1}}Unlimited{{else}}{{.quotaStatus.SearchRuns.Limit}}{{end}}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- AI Job Analysis Card -->
+        <div class="bg-slate-700 bg-opacity-50 rounded-lg p-4">
+          <h4 class="font-medium text-white mb-2">AI Job Analysis</h4>
+          <div class="grid grid-cols-2 gap-2 text-sm">
+            <div>
+              <span class="text-gray-400">Period:</span>
+              <span class="ml-2 text-gray-300">Monthly</span>
+            </div>
+            <div>
+              <span class="text-gray-400">Free:</span>
+              <span class="ml-2 text-gray-300">5</span>
+            </div>
+            <div class="col-span-2">
+              <span class="text-gray-400">Your Limit:</span>
+              <span class="ml-2 font-medium text-white">
+                {{if eq .quotaStatus.AIAnalysis.Limit -1}}Unlimited{{else}}{{.quotaStatus.AIAnalysis.Limit}}{{end}}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Information Section -->
+    <div class="space-y-3 md:space-y-4">
+      <div class="bg-blue-900 bg-opacity-30 border border-blue-700 rounded-lg p-3 md:p-4">
+        <div class="flex">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-blue-400 mr-2 md:mr-3 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <div>
+            <h4 class="text-sm font-medium text-blue-300 mb-1">About Quotas</h4>
+            <p class="text-xs md:text-sm text-gray-300">
+              {{if .isCloudMode}}
+                Quotas help ensure fair usage and system stability. Daily quotas reset at midnight UTC, while monthly quotas reset on the first day of each month.
+              {{else}}
+                As a self-hosted user, you have unlimited access to all features. The usage tracking is for informational purposes only.
+              {{end}}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {{if .isCloudMode}}
+      <div class="bg-primary bg-opacity-20 border border-primary rounded-lg p-3 md:p-4">
+        <div class="flex">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-primary mr-2 md:mr-3 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+          </svg>
+          <div>
+            <h4 class="text-sm font-medium text-primary mb-1">Need More?</h4>
+            <p class="text-xs md:text-sm text-gray-300">
+              Premium plans with higher limits are coming soon. Stay tuned for updates!
+            </p>
+          </div>
+        </div>
+      </div>
+      {{end}}
+    </div>
+
+    {{else}}
+    <!-- No quota data available -->
+    <div class="bg-slate-700 bg-opacity-50 rounded-lg p-8 text-center">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-16 w-16 text-gray-500 mx-auto mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+      </svg>
+      <p class="text-gray-400 text-base">Unable to load quota information. Please try again later.</p>
+    </div>
+    {{end}}
+  </div>
+</div>
+
+<!-- JavaScript for progress bars -->
+<script>
+// Set quota progress bars on page load
+document.addEventListener('DOMContentLoaded', function() {
+  const progressBars = document.querySelectorAll('.bg-primary[data-used][data-limit]');
+  progressBars.forEach(bar => {
+    const used = parseInt(bar.dataset.used);
+    const limit = parseInt(bar.dataset.limit);
+    
+    if (limit > 0) {
+      const percentage = Math.min((used / limit) * 100, 100);
+      bar.style.width = percentage + '%';
+      
+      // Add color variations based on usage
+      if (percentage >= 90) {
+        bar.classList.add('bg-red-500');
+        bar.classList.remove('bg-primary');
+      } else if (percentage >= 75) {
+        bar.classList.add('bg-yellow-500');
+        bar.classList.remove('bg-primary');
+      }
+    } else {
+      bar.style.width = '0%';
+    }
+  });
+});
+</script>
+
+<!-- Include auto-dismiss alerts script -->
+{{template "partials/auto-dismiss-alerts.html" .}}
+{{end}}

--- a/templates/settings/settings_search_preferences.html
+++ b/templates/settings/settings_search_preferences.html
@@ -1,0 +1,651 @@
+{{define "settings-search-preferences-content"}}
+<div class="mx-0 md:max-w-6xl md:mx-auto relative">
+  <!-- Alert container for form responses -->
+  <div id="form-alert-container" class="mb-4 md:mb-6 px-4 md:px-0" hx-swap-oob="true" aria-live="polite"></div>
+  
+  <!-- Content container with responsive padding -->
+  <div class="relative p-4 md:p-6 bg-slate-800 bg-opacity-70 backdrop-blur-xl rounded-none md:rounded-xl shadow-2xl border-0 md:border border-white border-opacity-10">
+    
+    <!-- Page Header -->
+    <div class="mb-6 pb-6 border-b border-slate-700 border-opacity-50">
+      <h2 class="text-xl md:text-2xl font-bold text-white mb-2">Job Search Preferences</h2>
+      <p class="text-sm md:text-base text-gray-400">Configure your job search criteria for the browser extension to automatically discover relevant opportunities.</p>
+    </div>
+
+    <!-- Add New Preference Form -->
+    <div class="mb-6 pb-6 border-b border-slate-700 border-opacity-50">
+      <h3 class="text-lg md:text-xl font-semibold mb-4 text-white">Add New Search Preference</h3>
+      
+      <form action="/settings/search-preferences" method="POST" hx-post="/settings/search-preferences" hx-target="#form-alert-container" hx-swap="innerHTML" hx-indicator=".preference-indicator" class="space-y-4 md:space-y-6">
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
+          <div class="space-y-1">
+            <label for="job_title" class="block text-sm font-medium text-gray-300">
+              Job Title <span class="text-red-500">*</span>
+            </label>
+            <input type="text" 
+                   id="job_title" 
+                   name="job_title" 
+                   required 
+                   maxlength="100"
+                   placeholder="e.g., Senior Backend Engineer"
+                   class="w-full px-3 py-3 md:py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-base md:text-sm touch-manipulation">
+          </div>
+          
+          <div class="space-y-1">
+            <label for="location" class="block text-sm font-medium text-gray-300">
+              Location <span class="text-red-500">*</span>
+            </label>
+            <input type="text" 
+                   id="location" 
+                   name="location" 
+                   required 
+                   maxlength="100"
+                   placeholder="e.g., Remote, San Francisco, New York"
+                   class="w-full px-3 py-3 md:py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-base md:text-sm touch-manipulation">
+          </div>
+        </div>
+        
+        <div class="space-y-1">
+          <label for="skills" class="block text-sm font-medium text-gray-300">Skills (Optional)</label>
+          <div class="skills-input-container">
+            <div id="skills-tags" class="flex flex-wrap gap-2 mb-2 min-h-[2rem]"></div>
+            <div class="flex gap-2">
+              <input type="text" id="skills-input" placeholder="Type to search skills or add custom..."
+                     class="flex-1 px-3 py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-sm"
+                     onkeydown="if(event.key==='Enter'){event.preventDefault();addSkill();}">
+              <button type="button" class="px-3 py-2 bg-slate-600 hover:bg-slate-500 text-white text-sm rounded-md transition-colors"
+                      onclick="addSkill()">
+                Add
+              </button>
+            </div>
+            <p class="text-xs text-gray-400 mt-1">Add skills to filter jobs more precisely (max 10)</p>
+            <textarea id="skills" name="skills" class="hidden"></textarea>
+          </div>
+        </div>
+        
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
+          <div class="space-y-1">
+            <label for="max_age" class="block text-sm font-medium text-gray-300">
+              Maximum Job Age <span class="text-red-500">*</span>
+            </label>
+            <select id="max_age" 
+                    name="max_age" 
+                    required
+                    class="w-full px-3 py-3 md:py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-base md:text-sm touch-manipulation">
+              {{range .maxAgeOptions}}
+                <option value="{{.Value}}" {{if .Selected}}selected{{end}}>{{.Label}}</option>
+              {{end}}
+            </select>
+          </div>
+          
+          <div class="flex items-end">
+            <label class="flex items-center cursor-pointer h-[46px] md:h-[38px]">
+              <input type="checkbox" 
+                     name="is_active" 
+                     value="on"
+                     checked
+                     class="mr-2 h-5 w-5 md:h-4 md:w-4 text-primary bg-slate-700 border-slate-600 rounded focus:ring-2 focus:ring-primary focus:ring-offset-0 focus:ring-offset-slate-800">
+              <span class="text-sm text-gray-300">Active</span>
+            </label>
+          </div>
+        </div>
+        
+        <div class="flex flex-col sm:flex-row justify-end gap-4 pt-4 md:pt-6 border-t border-slate-700">
+          <button type="submit" 
+                  class="px-4 py-2 bg-primary hover:bg-primary-dark text-white font-medium rounded-md transition-colors duration-300 flex items-center justify-center touch-manipulation text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">
+            <span class="preference-indicator hidden mr-2">
+              <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+            </span>
+            Add Preference
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <!-- Existing Preferences List -->
+    <div>
+      <h3 class="text-lg md:text-xl font-semibold mb-4 text-white">Your Search Preferences</h3>
+      
+      {{if not .preferences}}
+        <div class="bg-slate-700 bg-opacity-50 rounded-lg p-6 md:p-8 text-center">
+          <p class="text-gray-400 text-sm md:text-base">No search preferences configured yet. Add your first preference above to get started!</p>
+        </div>
+      {{else}}
+        <div class="grid gap-3 md:gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+          {{range .preferences}}
+            <div class="preference-card bg-slate-800 rounded-lg shadow-lg overflow-hidden hover:bg-slate-700 transition-all duration-200 group cursor-pointer" 
+                 data-id="{{.ID}}"
+                 data-job-title="{{.JobTitle}}"
+                 data-location="{{.Location}}"
+                 data-skills="{{range $i, $skill := .Skills}}{{if $i}},{{end}}{{$skill}}{{end}}"
+                 data-max-age="{{.MaxAge}}"
+                 data-is-active="{{.IsActive}}"
+                 onclick="editPreference('{{.ID}}')">
+              <div class="px-4 md:px-5 py-4 md:py-5">
+                <!-- Header with status badge -->
+                <div class="flex justify-between items-start mb-3">
+                  <h4 class="text-base md:text-lg font-semibold text-white group-hover:text-primary transition-colors flex-1 min-w-0 pr-2 flex items-center">
+                    {{.JobTitle}}
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 ml-2 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                    </svg>
+                  </h4>
+                  <div class="flex-none">
+                    <span class="text-xs px-2 py-1 rounded-full {{if .IsActive}}bg-primary bg-opacity-20 text-primary{{else}}bg-gray-600 bg-opacity-20 text-gray-400{{end}}">
+                      {{if .IsActive}}Active{{else}}Inactive{{end}}
+                    </span>
+                  </div>
+                </div>
+                
+                <!-- Details -->
+                <div class="space-y-2 mb-4">
+                  <p class="text-sm text-gray-300 flex items-center">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5 text-gray-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                    </svg>
+                    <span class="truncate">{{.Location}}</span>
+                  </p>
+                  <p class="text-sm text-gray-400 flex items-center">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1.5 text-gray-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                    </svg>
+                    <span>Max age: {{.GetMaxAgeDisplay}}</span>
+                  </p>
+                  {{if .Skills}}
+                  <div class="mt-2 flex items-center gap-1 text-xs text-gray-400">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 text-gray-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+                    </svg>
+                    <span class="truncate">
+                      {{range $i, $skill := .Skills}}{{if $i}}, {{end}}{{$skill}}{{end}}
+                    </span>
+                  </div>
+                  {{end}}
+                </div>
+                
+                <!-- Actions -->
+                <div class="flex items-center justify-between border-t border-slate-700 pt-3 -mx-4 md:-mx-5 px-4 md:px-5" onclick="event.stopPropagation()">
+                  <!-- Toggle Switch -->
+                  <button onclick="togglePreference('{{.ID}}')" 
+                          class="flex items-center space-x-2 text-sm text-gray-400 hover:text-white transition-colors">
+                    <span class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors {{if .IsActive}}bg-primary{{else}}bg-slate-600{{end}}">
+                      <span class="sr-only">Toggle active</span>
+                      <span class="inline-block h-3 w-3 transform rounded-full bg-white transition-transform {{if .IsActive}}translate-x-5{{else}}translate-x-1{{end}}"></span>
+                    </span>
+                    <span>Toggle</span>
+                  </button>
+                  
+                  <!-- Delete Button -->
+                  <button onclick="deletePreference('{{.ID}}')" 
+                          class="text-sm text-red-400 hover:text-red-300 transition-colors flex items-center space-x-1">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                    <span>Delete</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          {{end}}
+        </div>
+      {{end}}
+      
+      <!-- Limit Notice -->
+      {{if .preferences}}
+        <div class="mt-6 text-xs md:text-sm text-gray-500 text-center">
+          You have {{len .preferences}} of {{.maxPreferences}} preferences configured.
+        </div>
+      {{end}}
+    </div>
+  </div>
+</div>
+
+<!-- Edit Modal -->
+<div id="editModal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden" onclick="closeEditModal(event)">
+  <div class="flex items-center justify-center min-h-screen px-4">
+    <div class="bg-slate-800 rounded-xl shadow-2xl max-w-md w-full p-6 relative" onclick="event.stopPropagation()">
+      <h3 class="text-xl font-semibold text-white mb-4">Edit Search Preference</h3>
+      
+      <form id="editForm" method="POST" class="space-y-4">
+        <input type="hidden" id="edit_preference_id" name="preference_id">
+        
+        <div class="space-y-1">
+          <label for="edit_job_title" class="block text-sm font-medium text-gray-300">
+            Job Title <span class="text-red-500">*</span>
+          </label>
+          <input type="text" 
+                 id="edit_job_title" 
+                 name="job_title" 
+                 required 
+                 maxlength="100"
+                 class="w-full px-3 py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
+        </div>
+        
+        <div class="space-y-1">
+          <label for="edit_location" class="block text-sm font-medium text-gray-300">
+            Location <span class="text-red-500">*</span>
+          </label>
+          <input type="text" 
+                 id="edit_location" 
+                 name="location" 
+                 required 
+                 maxlength="100"
+                 class="w-full px-3 py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
+        </div>
+        
+        <div class="space-y-1">
+          <label for="edit_skills" class="block text-sm font-medium text-gray-300">Skills (Optional)</label>
+          <div class="skills-input-container" id="edit-skills-container">
+            <div id="edit-skills-tags" class="flex flex-wrap gap-2 mb-2 min-h-[2rem]"></div>
+            <div class="flex gap-2">
+              <input type="text" id="edit-skills-input" placeholder="Type to search skills or add custom..."
+                     class="flex-1 px-3 py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-sm"
+                     onkeydown="if(event.key==='Enter'){event.preventDefault();addEditSkill();}">
+              <button type="button" class="px-3 py-2 bg-slate-600 hover:bg-slate-500 text-white text-sm rounded-md transition-colors"
+                      onclick="addEditSkill()">
+                Add
+              </button>
+            </div>
+            <p class="text-xs text-gray-400 mt-1">Add skills to filter jobs more precisely (max 10)</p>
+            <textarea id="edit_skills" name="skills" class="hidden"></textarea>
+          </div>
+        </div>
+        
+        <div class="space-y-1">
+          <label for="edit_max_age" class="block text-sm font-medium text-gray-300">
+            Maximum Job Age <span class="text-red-500">*</span>
+          </label>
+          <select id="edit_max_age" 
+                  name="max_age" 
+                  required
+                  class="w-full px-3 py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
+            {{range .maxAgeOptions}}
+              <option value="{{.Value}}">{{.Label}}</option>
+            {{end}}
+          </select>
+        </div>
+        
+        <div class="flex items-center">
+          <label class="flex items-center cursor-pointer">
+            <input type="checkbox" 
+                   id="edit_is_active"
+                   name="is_active" 
+                   value="on"
+                   class="mr-2 h-4 w-4 text-primary bg-slate-700 border-slate-600 rounded focus:ring-2 focus:ring-primary focus:ring-offset-0 focus:ring-offset-slate-800">
+            <span class="text-sm text-gray-300">Active</span>
+          </label>
+        </div>
+        
+        <div class="flex flex-col sm:flex-row justify-end gap-3 pt-4 border-t border-slate-700">
+          <button type="button" 
+                  onclick="closeEditModal()" 
+                  class="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white font-medium rounded-md transition-colors duration-300">
+            Cancel
+          </button>
+          <button type="submit" 
+                  class="px-4 py-2 bg-primary hover:bg-primary-dark text-white font-medium rounded-md transition-colors duration-300 flex items-center justify-center">
+            <span class="edit-indicator hidden mr-2">
+              <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+            </span>
+            Update Preference
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- JavaScript for AJAX operations -->
+<script>
+function togglePreference(id) {
+  // Find the card
+  const card = document.querySelector(`.preference-card[data-id="${id}"]`);
+  if (card) {
+    card.style.opacity = '0.6';
+    card.style.pointerEvents = 'none';
+  }
+  
+  fetch(`/settings/search-preferences/${id}/toggle`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    }
+  })
+  .then(response => response.json())
+  .then(data => {
+    if (data.message) {
+      // Update UI without reload for better UX
+      if (card) {
+        const badge = card.querySelector('.rounded-full');
+        const toggle = card.querySelector('span.relative');
+        const toggleDot = toggle.querySelector('span.inline-block');
+        
+        if (badge.classList.contains('bg-primary')) {
+          // Deactivating
+          badge.classList.remove('bg-primary', 'text-primary');
+          badge.classList.add('bg-gray-600', 'text-gray-400');
+          badge.textContent = 'Inactive';
+          toggle.classList.remove('bg-primary');
+          toggle.classList.add('bg-slate-600');
+          toggleDot.classList.remove('translate-x-5');
+          toggleDot.classList.add('translate-x-1');
+        } else {
+          // Activating
+          badge.classList.remove('bg-gray-600', 'text-gray-400');
+          badge.classList.add('bg-primary', 'text-primary');
+          badge.textContent = 'Active';
+          toggle.classList.remove('bg-slate-600');
+          toggle.classList.add('bg-primary');
+          toggleDot.classList.remove('translate-x-1');
+          toggleDot.classList.add('translate-x-5');
+        }
+        
+        card.style.opacity = '1';
+        card.style.pointerEvents = 'auto';
+        
+        // Show toast notification if available
+        if (typeof showToast === 'function') {
+          showToast(data.message || 'Preference updated', 'success');
+        }
+      }
+    } else {
+      if (card) {
+        card.style.opacity = '1';
+        card.style.pointerEvents = 'auto';
+      }
+      if (typeof showToast === 'function') {
+        showToast(data.error || 'Failed to toggle preference', 'error');
+      }
+    }
+  })
+  .catch(error => {
+    console.error('Error:', error);
+    if (card) {
+      card.style.opacity = '1';
+      card.style.pointerEvents = 'auto';
+    }
+    if (typeof showToast === 'function') {
+      showToast('Failed to toggle preference', 'error');
+    }
+  });
+}
+
+function deletePreference(id) {
+  if (!confirm('Are you sure you want to delete this search preference?')) {
+    return;
+  }
+  
+  fetch(`/settings/search-preferences/${id}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    }
+  })
+  .then(response => response.json())
+  .then(data => {
+    if (data.message) {
+      // Remove the card with animation
+      const card = document.querySelector(`.preference-card[data-id="${id}"]`);
+      card.style.opacity = '0';
+      card.style.transform = 'translateX(-20px)';
+      setTimeout(() => {
+        window.location.reload();
+      }, 300);
+    } else {
+      alert(data.error || 'Failed to delete preference');
+    }
+  })
+  .catch(error => {
+    console.error('Error:', error);
+    alert('Failed to delete preference');
+  });
+}
+
+function editPreference(id) {
+  const card = document.querySelector(`.preference-card[data-id="${id}"]`);
+  if (!card) return;
+  
+  // Get preference data from card attributes
+  const jobTitle = card.dataset.jobTitle;
+  const location = card.dataset.location;
+  const skillsStr = card.dataset.skills;
+  const maxAge = card.dataset.maxAge;
+  const isActive = card.dataset.isActive === 'true';
+  
+  // Populate the edit form
+  document.getElementById('edit_preference_id').value = id;
+  document.getElementById('edit_job_title').value = jobTitle;
+  document.getElementById('edit_location').value = location;
+  document.getElementById('edit_max_age').value = maxAge;
+  document.getElementById('edit_is_active').checked = isActive;
+  
+  // Clear and populate skills
+  const editSkillsContainer = document.getElementById('edit-skills-tags');
+  editSkillsContainer.innerHTML = '';
+  
+  if (skillsStr) {
+    const skills = skillsStr.split(',');
+    skills.forEach(skill => {
+      if (skill.trim()) {
+        createEditSkillTag(skill.trim());
+      }
+    });
+    updateEditSkills();
+  }
+  
+  // Show the modal
+  document.getElementById('editModal').classList.remove('hidden');
+}
+
+function closeEditModal(event) {
+  if (!event || event.target.id === 'editModal') {
+    document.getElementById('editModal').classList.add('hidden');
+  }
+}
+
+// Handle edit form submission
+document.getElementById('editForm').addEventListener('submit', function(e) {
+  e.preventDefault();
+  
+  const formData = new FormData(this);
+  const preferenceId = formData.get('preference_id');
+  
+  // Show loading indicator
+  const indicator = document.querySelector('.edit-indicator');
+  indicator.classList.remove('hidden');
+  
+  // Prepare data
+  const data = {
+    job_title: formData.get('job_title'),
+    location: formData.get('location'),
+    skills: formData.get('skills') ? formData.get('skills').split(',').map(s => s.trim()).filter(s => s) : [],
+    max_age: parseInt(formData.get('max_age')),
+    is_active: formData.has('is_active')
+  };
+  
+  fetch(`/settings/search-preferences/${preferenceId}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data)
+  })
+  .then(response => response.json())
+  .then(data => {
+    indicator.classList.add('hidden');
+    
+    if (data.message) {
+      closeEditModal();
+      window.location.reload(); // Reload to show updated preferences
+    } else {
+      alert(data.error || 'Failed to update preference');
+    }
+  })
+  .catch(error => {
+    console.error('Error:', error);
+    indicator.classList.add('hidden');
+    alert('Failed to update preference');
+  });
+});
+
+// Edit form skills functions
+function addEditSkill(skillText = null) {
+  const input = document.getElementById('edit-skills-input');
+  const skill = (skillText || input.value).trim();
+  
+  if (skill && !hasEditSkill(skill)) {
+    createEditSkillTag(skill);
+    input.value = '';
+    updateEditSkills();
+  }
+}
+
+function hasEditSkill(skill) {
+  const tags = document.querySelectorAll('#edit-skills-tags .skill-tag');
+  return Array.from(tags).some(tag => 
+    tag.textContent.trim().toLowerCase() === skill.toLowerCase()
+  );
+}
+
+function createEditSkillTag(skill) {
+  const container = document.getElementById('edit-skills-tags');
+  const tag = document.createElement('span');
+  tag.className = 'skill-tag inline-flex items-center px-1 py-0.5 rounded text-xs font-medium bg-primary bg-opacity-20 text-primary border border-primary border-opacity-30';
+  
+  const skillText = document.createTextNode(skill);
+  tag.appendChild(skillText);
+  
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'ml-1 inline-flex items-center justify-center w-4 h-4 text-primary hover:text-red-400 focus:outline-none';
+  button.onclick = function() { removeEditSkillTag(this); };
+  
+  button.innerHTML = `
+    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+    </svg>
+  `;
+  
+  tag.appendChild(button);
+  container.appendChild(tag);
+}
+
+function removeEditSkillTag(button) {
+  const tag = button.closest('.skill-tag');
+  if (tag) {
+    tag.remove();
+    updateEditSkills();
+  }
+}
+
+function updateEditSkills() {
+  const tags = document.querySelectorAll('#edit-skills-tags .skill-tag');
+  const skills = Array.from(tags).map(tag => tag.textContent.trim());
+  document.getElementById('edit_skills').value = skills.join(', ');
+}
+</script>
+
+<!-- Include auto-dismiss alerts script -->
+{{template "partials/auto-dismiss-alerts.html" .}}
+
+<!-- Responsive styles for mobile -->
+<style>
+.preference-card {
+  transition: all 0.3s ease;
+}
+
+/* Line clamp for long text */
+.truncate {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Grid responsive layout */
+@media (max-width: 640px) {
+  .preference-card {
+    touch-action: manipulation;
+  }
+  
+  /* Stack actions on very small screens */
+  @media (max-width: 360px) {
+    .preference-card .border-t {
+      flex-direction: column;
+      gap: 0.75rem;
+      align-items: stretch;
+    }
+    
+    .preference-card button {
+      justify-content: center;
+    }
+  }
+}
+
+/* Desktop hover effect with shadow */
+@media (min-width: 768px) {
+  .preference-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  }
+}
+
+/* Modal animation */
+#editModal {
+  animation: fadeIn 0.2s ease-out;
+}
+
+#editModal > div > div {
+  animation: slideIn 0.3s ease-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideIn {
+  from { 
+    transform: translateY(-20px);
+    opacity: 0;
+  }
+  to { 
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+
+/* Form field focus states for mobile */
+@media (max-width: 768px) {
+  input:focus, textarea:focus, select:focus {
+    transform: scale(1.01);
+    transition: transform 0.2s ease;
+  }
+}
+
+/* Smooth transitions for delete animation */
+.preference-card[style*="opacity: 0"] {
+  pointer-events: none;
+  transform: translateX(-20px);
+}
+
+/* Toggle switch focus state */
+.preference-card button:focus-visible span.relative {
+  outline: 2px solid #0D9488;
+  outline-offset: 2px;
+}
+
+/* Ensure action buttons have good touch targets */
+.preference-card button {
+  min-height: 36px;
+  padding: 0.5rem;
+}
+</style>
+{{end}}

--- a/templates/settings/settings_search_preferences.html
+++ b/templates/settings/settings_search_preferences.html
@@ -12,6 +12,7 @@
       <p class="text-sm md:text-base text-gray-400">Configure your job search criteria for the browser extension to automatically discover relevant opportunities.</p>
     </div>
 
+
     <!-- Add New Preference Form -->
     <div class="mb-6 pb-6 border-b border-slate-700 border-opacity-50">
       <h3 class="text-lg md:text-xl font-semibold mb-4 text-white">Add New Search Preference</h3>

--- a/templates/settings/settings_search_preferences.html
+++ b/templates/settings/settings_search_preferences.html
@@ -2,10 +2,10 @@
 <div class="mx-0 md:max-w-6xl md:mx-auto relative">
   <!-- Alert container for form responses -->
   <div id="form-alert-container" class="mb-4 md:mb-6 px-4 md:px-0" hx-swap-oob="true" aria-live="polite"></div>
-  
+
   <!-- Content container with responsive padding -->
   <div class="relative p-4 md:p-6 bg-slate-800 bg-opacity-70 backdrop-blur-xl rounded-none md:rounded-xl shadow-2xl border-0 md:border border-white border-opacity-10">
-    
+
     <!-- Page Header -->
     <div class="mb-6 pb-6 border-b border-slate-700 border-opacity-50">
       <h2 class="text-xl md:text-2xl font-bold text-white mb-2">Job Search Preferences</h2>
@@ -16,36 +16,36 @@
     <!-- Add New Preference Form -->
     <div class="mb-6 pb-6 border-b border-slate-700 border-opacity-50">
       <h3 class="text-lg md:text-xl font-semibold mb-4 text-white">Add New Search Preference</h3>
-      
+
       <form action="/settings/search-preferences" method="POST" hx-post="/settings/search-preferences" hx-target="#form-alert-container" hx-swap="innerHTML" hx-indicator=".preference-indicator" class="space-y-4 md:space-y-6">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
           <div class="space-y-1">
             <label for="job_title" class="block text-sm font-medium text-gray-300">
               Job Title <span class="text-red-500">*</span>
             </label>
-            <input type="text" 
-                   id="job_title" 
-                   name="job_title" 
-                   required 
+            <input type="text"
+                   id="job_title"
+                   name="job_title"
+                   required
                    maxlength="100"
                    placeholder="e.g., Senior Backend Engineer"
                    class="w-full px-3 py-3 md:py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-base md:text-sm touch-manipulation">
           </div>
-          
+
           <div class="space-y-1">
             <label for="location" class="block text-sm font-medium text-gray-300">
               Location <span class="text-red-500">*</span>
             </label>
-            <input type="text" 
-                   id="location" 
-                   name="location" 
-                   required 
+            <input type="text"
+                   id="location"
+                   name="location"
+                   required
                    maxlength="100"
                    placeholder="e.g., Remote, San Francisco, New York"
                    class="w-full px-3 py-3 md:py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-base md:text-sm touch-manipulation">
           </div>
         </div>
-        
+
         <div class="space-y-1">
           <label for="skills" class="block text-sm font-medium text-gray-300">Skills (Optional)</label>
           <div class="skills-input-container">
@@ -63,14 +63,14 @@
             <textarea id="skills" name="skills" class="hidden"></textarea>
           </div>
         </div>
-        
+
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 md:gap-6">
           <div class="space-y-1">
             <label for="max_age" class="block text-sm font-medium text-gray-300">
               Maximum Job Age <span class="text-red-500">*</span>
             </label>
-            <select id="max_age" 
-                    name="max_age" 
+            <select id="max_age"
+                    name="max_age"
                     required
                     class="w-full px-3 py-3 md:py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-base md:text-sm touch-manipulation">
               {{range .maxAgeOptions}}
@@ -78,11 +78,11 @@
               {{end}}
             </select>
           </div>
-          
+
           <div class="flex items-end">
             <label class="flex items-center cursor-pointer h-[46px] md:h-[38px]">
-              <input type="checkbox" 
-                     name="is_active" 
+              <input type="checkbox"
+                     name="is_active"
                      value="on"
                      checked
                      class="mr-2 h-5 w-5 md:h-4 md:w-4 text-primary bg-slate-700 border-slate-600 rounded focus:ring-2 focus:ring-primary focus:ring-offset-0 focus:ring-offset-slate-800">
@@ -90,9 +90,9 @@
             </label>
           </div>
         </div>
-        
+
         <div class="flex flex-col sm:flex-row justify-end gap-4 pt-4 md:pt-6 border-t border-slate-700">
-          <button type="submit" 
+          <button type="submit"
                   class="px-4 py-2 bg-primary hover:bg-primary-dark text-white font-medium rounded-md transition-colors duration-300 flex items-center justify-center touch-manipulation text-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">
             <span class="preference-indicator hidden mr-2">
               <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -109,15 +109,15 @@
     <!-- Existing Preferences List -->
     <div>
       <h3 class="text-lg md:text-xl font-semibold mb-4 text-white">Your Search Preferences</h3>
-      
+
       {{if not .preferences}}
         <div class="bg-slate-700 bg-opacity-50 rounded-lg p-6 md:p-8 text-center">
-          <p class="text-gray-400 text-sm md:text-base">No search preferences configured yet. Add your first preference above to get started!</p>
+          <p class="text-gray-400 text-sm md:text-base">No search preferences configured yet. Add your first preference to get started!</p>
         </div>
       {{else}}
         <div class="grid gap-3 md:gap-4 grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
           {{range .preferences}}
-            <div class="preference-card bg-slate-800 rounded-lg shadow-lg overflow-hidden hover:bg-slate-700 transition-all duration-200 group cursor-pointer" 
+            <div class="preference-card bg-slate-800 rounded-lg shadow-lg overflow-hidden hover:bg-slate-700 transition-all duration-200 group cursor-pointer"
                  data-id="{{.ID}}"
                  data-job-title="{{.JobTitle}}"
                  data-location="{{.Location}}"
@@ -140,7 +140,7 @@
                     </span>
                   </div>
                 </div>
-                
+
                 <!-- Details -->
                 <div class="space-y-2 mb-4">
                   <p class="text-sm text-gray-300 flex items-center">
@@ -167,11 +167,11 @@
                   </div>
                   {{end}}
                 </div>
-                
+
                 <!-- Actions -->
                 <div class="flex items-center justify-between border-t border-slate-700 pt-3 -mx-4 md:-mx-5 px-4 md:px-5" onclick="event.stopPropagation()">
                   <!-- Toggle Switch -->
-                  <button onclick="togglePreference('{{.ID}}')" 
+                  <button onclick="togglePreference('{{.ID}}')"
                           class="flex items-center space-x-2 text-sm text-gray-400 hover:text-white transition-colors">
                     <span class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors {{if .IsActive}}bg-primary{{else}}bg-slate-600{{end}}">
                       <span class="sr-only">Toggle active</span>
@@ -179,9 +179,9 @@
                     </span>
                     <span>Toggle</span>
                   </button>
-                  
+
                   <!-- Delete Button -->
-                  <button onclick="deletePreference('{{.ID}}')" 
+                  <button onclick="deletePreference('{{.ID}}')"
                           class="text-sm text-red-400 hover:text-red-300 transition-colors flex items-center space-x-1">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -194,7 +194,7 @@
           {{end}}
         </div>
       {{end}}
-      
+
       <!-- Limit Notice -->
       {{if .preferences}}
         <div class="mt-6 text-xs md:text-sm text-gray-500 text-center">
@@ -210,34 +210,34 @@
   <div class="flex items-center justify-center min-h-screen px-4">
     <div class="bg-slate-800 rounded-xl shadow-2xl max-w-md w-full p-6 relative" onclick="event.stopPropagation()">
       <h3 class="text-xl font-semibold text-white mb-4">Edit Search Preference</h3>
-      
+
       <form id="editForm" method="POST" class="space-y-4">
         <input type="hidden" id="edit_preference_id" name="preference_id">
-        
+
         <div class="space-y-1">
           <label for="edit_job_title" class="block text-sm font-medium text-gray-300">
             Job Title <span class="text-red-500">*</span>
           </label>
-          <input type="text" 
-                 id="edit_job_title" 
-                 name="job_title" 
-                 required 
+          <input type="text"
+                 id="edit_job_title"
+                 name="job_title"
+                 required
                  maxlength="100"
                  class="w-full px-3 py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
         </div>
-        
+
         <div class="space-y-1">
           <label for="edit_location" class="block text-sm font-medium text-gray-300">
             Location <span class="text-red-500">*</span>
           </label>
-          <input type="text" 
-                 id="edit_location" 
-                 name="location" 
-                 required 
+          <input type="text"
+                 id="edit_location"
+                 name="location"
+                 required
                  maxlength="100"
                  class="w-full px-3 py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
         </div>
-        
+
         <div class="space-y-1">
           <label for="edit_skills" class="block text-sm font-medium text-gray-300">Skills (Optional)</label>
           <div class="skills-input-container" id="edit-skills-container">
@@ -255,13 +255,13 @@
             <textarea id="edit_skills" name="skills" class="hidden"></textarea>
           </div>
         </div>
-        
+
         <div class="space-y-1">
           <label for="edit_max_age" class="block text-sm font-medium text-gray-300">
             Maximum Job Age <span class="text-red-500">*</span>
           </label>
-          <select id="edit_max_age" 
-                  name="max_age" 
+          <select id="edit_max_age"
+                  name="max_age"
                   required
                   class="w-full px-3 py-2 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
             {{range .maxAgeOptions}}
@@ -269,25 +269,25 @@
             {{end}}
           </select>
         </div>
-        
+
         <div class="flex items-center">
           <label class="flex items-center cursor-pointer">
-            <input type="checkbox" 
+            <input type="checkbox"
                    id="edit_is_active"
-                   name="is_active" 
+                   name="is_active"
                    value="on"
                    class="mr-2 h-4 w-4 text-primary bg-slate-700 border-slate-600 rounded focus:ring-2 focus:ring-primary focus:ring-offset-0 focus:ring-offset-slate-800">
             <span class="text-sm text-gray-300">Active</span>
           </label>
         </div>
-        
+
         <div class="flex flex-col sm:flex-row justify-end gap-3 pt-4 border-t border-slate-700">
-          <button type="button" 
-                  onclick="closeEditModal()" 
+          <button type="button"
+                  onclick="closeEditModal()"
                   class="px-4 py-2 bg-slate-700 hover:bg-slate-600 text-white font-medium rounded-md transition-colors duration-300">
             Cancel
           </button>
-          <button type="submit" 
+          <button type="submit"
                   class="px-4 py-2 bg-primary hover:bg-primary-dark text-white font-medium rounded-md transition-colors duration-300 flex items-center justify-center">
             <span class="edit-indicator hidden mr-2">
               <svg class="animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -312,7 +312,7 @@ function togglePreference(id) {
     card.style.opacity = '0.6';
     card.style.pointerEvents = 'none';
   }
-  
+
   fetch(`/settings/search-preferences/${id}/toggle`, {
     method: 'PATCH',
     headers: {
@@ -327,7 +327,7 @@ function togglePreference(id) {
         const badge = card.querySelector('.rounded-full');
         const toggle = card.querySelector('span.relative');
         const toggleDot = toggle.querySelector('span.inline-block');
-        
+
         if (badge.classList.contains('bg-primary')) {
           // Deactivating
           badge.classList.remove('bg-primary', 'text-primary');
@@ -347,10 +347,10 @@ function togglePreference(id) {
           toggleDot.classList.remove('translate-x-1');
           toggleDot.classList.add('translate-x-5');
         }
-        
+
         card.style.opacity = '1';
         card.style.pointerEvents = 'auto';
-        
+
         // Show toast notification if available
         if (typeof showToast === 'function') {
           showToast(data.message || 'Preference updated', 'success');
@@ -382,7 +382,7 @@ function deletePreference(id) {
   if (!confirm('Are you sure you want to delete this search preference?')) {
     return;
   }
-  
+
   fetch(`/settings/search-preferences/${id}`, {
     method: 'DELETE',
     headers: {
@@ -412,25 +412,25 @@ function deletePreference(id) {
 function editPreference(id) {
   const card = document.querySelector(`.preference-card[data-id="${id}"]`);
   if (!card) return;
-  
+
   // Get preference data from card attributes
   const jobTitle = card.dataset.jobTitle;
   const location = card.dataset.location;
   const skillsStr = card.dataset.skills;
   const maxAge = card.dataset.maxAge;
   const isActive = card.dataset.isActive === 'true';
-  
+
   // Populate the edit form
   document.getElementById('edit_preference_id').value = id;
   document.getElementById('edit_job_title').value = jobTitle;
   document.getElementById('edit_location').value = location;
   document.getElementById('edit_max_age').value = maxAge;
   document.getElementById('edit_is_active').checked = isActive;
-  
+
   // Clear and populate skills
   const editSkillsContainer = document.getElementById('edit-skills-tags');
   editSkillsContainer.innerHTML = '';
-  
+
   if (skillsStr) {
     const skills = skillsStr.split(',');
     skills.forEach(skill => {
@@ -440,7 +440,7 @@ function editPreference(id) {
     });
     updateEditSkills();
   }
-  
+
   // Show the modal
   document.getElementById('editModal').classList.remove('hidden');
 }
@@ -454,14 +454,14 @@ function closeEditModal(event) {
 // Handle edit form submission
 document.getElementById('editForm').addEventListener('submit', function(e) {
   e.preventDefault();
-  
+
   const formData = new FormData(this);
   const preferenceId = formData.get('preference_id');
-  
+
   // Show loading indicator
   const indicator = document.querySelector('.edit-indicator');
   indicator.classList.remove('hidden');
-  
+
   // Prepare data
   const data = {
     job_title: formData.get('job_title'),
@@ -470,7 +470,7 @@ document.getElementById('editForm').addEventListener('submit', function(e) {
     max_age: parseInt(formData.get('max_age')),
     is_active: formData.has('is_active')
   };
-  
+
   fetch(`/settings/search-preferences/${preferenceId}`, {
     method: 'PUT',
     headers: {
@@ -481,7 +481,7 @@ document.getElementById('editForm').addEventListener('submit', function(e) {
   .then(response => response.json())
   .then(data => {
     indicator.classList.add('hidden');
-    
+
     if (data.message) {
       closeEditModal();
       window.location.reload(); // Reload to show updated preferences
@@ -500,7 +500,7 @@ document.getElementById('editForm').addEventListener('submit', function(e) {
 function addEditSkill(skillText = null) {
   const input = document.getElementById('edit-skills-input');
   const skill = (skillText || input.value).trim();
-  
+
   if (skill && !hasEditSkill(skill)) {
     createEditSkillTag(skill);
     input.value = '';
@@ -510,7 +510,7 @@ function addEditSkill(skillText = null) {
 
 function hasEditSkill(skill) {
   const tags = document.querySelectorAll('#edit-skills-tags .skill-tag');
-  return Array.from(tags).some(tag => 
+  return Array.from(tags).some(tag =>
     tag.textContent.trim().toLowerCase() === skill.toLowerCase()
   );
 }
@@ -519,21 +519,21 @@ function createEditSkillTag(skill) {
   const container = document.getElementById('edit-skills-tags');
   const tag = document.createElement('span');
   tag.className = 'skill-tag inline-flex items-center px-1 py-0.5 rounded text-xs font-medium bg-primary bg-opacity-20 text-primary border border-primary border-opacity-30';
-  
+
   const skillText = document.createTextNode(skill);
   tag.appendChild(skillText);
-  
+
   const button = document.createElement('button');
   button.type = 'button';
   button.className = 'ml-1 inline-flex items-center justify-center w-4 h-4 text-primary hover:text-red-400 focus:outline-none';
   button.onclick = function() { removeEditSkillTag(this); };
-  
+
   button.innerHTML = `
     <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
     </svg>
   `;
-  
+
   tag.appendChild(button);
   container.appendChild(tag);
 }
@@ -574,7 +574,7 @@ function updateEditSkills() {
   .preference-card {
     touch-action: manipulation;
   }
-  
+
   /* Stack actions on very small screens */
   @media (max-width: 360px) {
     .preference-card .border-t {
@@ -582,7 +582,7 @@ function updateEditSkills() {
       gap: 0.75rem;
       align-items: stretch;
     }
-    
+
     .preference-card button {
       justify-content: center;
     }
@@ -612,11 +612,11 @@ function updateEditSkills() {
 }
 
 @keyframes slideIn {
-  from { 
+  from {
     transform: translateY(-20px);
     opacity: 0;
   }
-  to { 
+  to {
     transform: translateY(0);
     opacity: 1;
   }

--- a/templates/settings/settings_security.html
+++ b/templates/settings/settings_security.html
@@ -7,7 +7,8 @@
   <!-- Content container -->
   <div class="relative p-4 md:p-6 bg-slate-800 bg-opacity-70 backdrop-blur-xl rounded-xl shadow-2xl border border-white border-opacity-10">
 
-    <!-- Google Sign-In Section -->
+    {{if .isCloudMode}}
+    <!-- Google Sign-In Section (Cloud Mode) -->
     <div class="mb-6 pb-6 border-b border-slate-700 border-opacity-50">
       <h3 class="text-lg md:text-xl font-semibold mb-4 text-white border-b border-slate-700 pb-2">Google Account</h3>
 
@@ -24,8 +25,8 @@
               </svg>
             </div>
             <div>
-              <h4 class="text-base md:text-lg font-medium text-white">{{.user.Name}}</h4>
-              <p class="text-sm md:text-base text-gray-300">{{.user.Email}}</p>
+              <h4 class="text-base md:text-lg font-medium text-white">Google Account</h4>
+              <p class="text-sm md:text-base text-gray-300">{{.user.Username}}</p>
             </div>
           </div>
 
@@ -54,9 +55,107 @@
         </div>
       </div>
     </div>
+    {{else}}
+    <!-- Account Management Section (Self-Hosted Mode) -->
+    <div class="mb-6 pb-6 border-b border-slate-700 border-opacity-50">
+      <h3 class="text-lg md:text-xl font-semibold mb-4 text-white border-b border-slate-700 pb-2">Account Management</h3>
 
+      <form id="security-account-form" action="/settings/security/account" method="POST" hx-post="/settings/security/account" hx-target="#form-alert-container" hx-swap="innerHTML" hx-on::after-request="if(event.detail.successful && event.detail.xhr.responseText.includes('successfully')) { document.getElementById('current_password').value = ''; document.getElementById('new_password').value = ''; document.getElementById('confirm_password').value = ''; }" class="space-y-6">
+        <!-- Current Password (Required for any changes) -->
+        <div class="bg-slate-700 bg-opacity-40 rounded-lg p-4 md:p-6">
+          <h4 class="text-md font-medium text-white mb-4">Authentication Required</h4>
+          <div class="space-y-1">
+            <label for="current_password" class="block text-sm font-medium text-gray-300">
+              Current Password <span class="text-red-500">*</span>
+            </label>
+            <input type="password"
+                   id="current_password"
+                   name="current_password"
+                   required
+                   autocomplete="current-password"
+                   placeholder="Enter your current password"
+                   class="w-full px-3 py-2 rounded-md bg-slate-600 bg-opacity-70 border border-slate-500 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
+            <p class="text-xs text-gray-400 mt-1">Required to make any changes</p>
+          </div>
+        </div>
 
-    <!-- Connected Third-Party Services -->
+        <!-- Username Change -->
+        <div class="bg-slate-700 bg-opacity-40 rounded-lg p-4 md:p-6">
+          <h4 class="text-md font-medium text-white mb-4">Change Username</h4>
+          <div class="space-y-1">
+            <label for="new_username" class="block text-sm font-medium text-gray-300">
+              New Username
+            </label>
+            <input type="text"
+                   id="new_username"
+                   name="new_username"
+                   value="{{.user.Username}}"
+                   autocomplete="username"
+                   placeholder="Enter new username"
+                   class="w-full px-3 py-2 rounded-md bg-slate-600 bg-opacity-70 border border-slate-500 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
+            <p class="text-xs text-gray-400 mt-1">Leave blank to keep current username</p>
+          </div>
+        </div>
+
+        <!-- Password Change -->
+        <div class="bg-slate-700 bg-opacity-40 rounded-lg p-4 md:p-6">
+          <h4 class="text-md font-medium text-white mb-4">Change Password</h4>
+          <div class="space-y-4">
+            <div class="space-y-1">
+              <label for="new_password" class="block text-sm font-medium text-gray-300">
+                New Password
+              </label>
+              <input type="password"
+                     id="new_password"
+                     name="new_password"
+                     autocomplete="new-password"
+                     placeholder="Enter new password"
+                     class="w-full px-3 py-2 rounded-md bg-slate-600 bg-opacity-70 border border-slate-500 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
+            </div>
+
+            <div class="space-y-1">
+              <label for="confirm_password" class="block text-sm font-medium text-gray-300">
+                Confirm New Password
+              </label>
+              <input type="password"
+                     id="confirm_password"
+                     name="confirm_password"
+                     autocomplete="new-password"
+                     placeholder="Confirm new password"
+                     class="w-full px-3 py-2 rounded-md bg-slate-600 bg-opacity-70 border border-slate-500 text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors">
+            </div>
+            <p class="text-xs text-gray-400">Leave blank to keep current password</p>
+          </div>
+        </div>
+
+        <!-- Submit Button -->
+        <div class="flex justify-end pt-4">
+          <button type="submit"
+                  class="px-6 py-2 bg-primary hover:bg-primary-dark text-white font-medium rounded-md transition-colors duration-300">
+            Save Changes
+          </button>
+        </div>
+      </form>
+
+      <!-- Password Reset Hint -->
+      <div class="mt-6 p-4 bg-blue-900 bg-opacity-30 border border-blue-700 rounded-lg">
+        <div class="flex">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-blue-400 mr-3 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+          <div>
+            <h4 class="text-sm font-medium text-blue-300 mb-1">Forgot your password?</h4>
+            <p class="text-xs text-gray-300">
+              Restart the application with <code class="bg-slate-700 px-2 py-1 rounded text-xs">RESET_ADMIN_PASSWORD=true ./vega</code> to reset your password.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    {{end}}
+
+    {{if .isCloudMode}}
+    <!-- Connected Third-Party Services (Cloud Mode Only) -->
     <div class="mb-6 pb-6 border-b border-slate-700 border-opacity-50">
       <h3 class="text-xl font-semibold mb-4 text-white border-b border-slate-700 pb-2">Connected Services</h3>
 
@@ -84,8 +183,9 @@
         </div>
       </div>
     </div>
+    {{end}}
 
-    <!-- Account Activity Section -->
+    <!-- Account Activity Section (All Modes) -->
     <div>
       <h3 class="text-xl font-semibold mb-4 text-white border-b border-slate-700 pb-2">Account Activity</h3>
 
@@ -94,11 +194,11 @@
           <div>
             <h4 class="text-md font-medium text-white">Last Login</h4>
             <p class="text-gray-300 mt-1">
-              {{if .security.Activity.LastLogin.IsZero}}
+              {{if .user.LastLogin.IsZero}}
                 Never
               {{else}}
-                <span class="utc-time" data-utc="{{.security.Activity.LastLogin.Format "2006-01-02T15:04:05Z"}}" data-format="full">
-                  {{.security.Activity.LastLogin.Format "January 2, 2006 at 3:04 PM"}}
+                <span class="utc-time" data-utc="{{.user.LastLogin.Format "2006-01-02T15:04:05Z"}}" data-format="full">
+                  {{.user.LastLogin.Format "January 2, 2006 at 3:04 PM"}}
                 </span>
               {{end}}
             </p>
@@ -107,11 +207,11 @@
           <div>
             <h4 class="text-md font-medium text-white">Account Created</h4>
             <p class="text-gray-300 mt-1">
-              {{if .security.Activity.CreatedAt.IsZero}}
+              {{if .user.CreatedAt.IsZero}}
                 Unknown
               {{else}}
-                <span class="utc-time" data-utc="{{.security.Activity.CreatedAt.Format "2006-01-02T15:04:05Z"}}" data-format="date">
-                  {{.security.Activity.CreatedAt.Format "January 2, 2006"}}
+                <span class="utc-time" data-utc="{{.user.CreatedAt.Format "2006-01-02T15:04:05Z"}}" data-format="date">
+                  {{.user.CreatedAt.Format "January 2, 2006"}}
                 </span>
               {{end}}
             </p>
@@ -121,4 +221,7 @@
     </div>
   </div>
 </div>
+
+<!-- Include auto-dismiss alerts script -->
+{{template "partials/auto-dismiss-alerts.html" .}}
 {{end}}


### PR DESCRIPTION
## 🚀 What's this about?

This PR implements job search preferences, quota management system, and admin role functionality for Vega AI. It adds the ability for users to configure their job search preferences (skills, locations, seniority, etc.) and introduces a unified quota system for cloud deployments.

## 💡 Why this matters

As Vega AI prepares for cloud deployment, we need:
- **User Preferences**: Allow users to save and manage their job search criteria for personalized job discovery
- **Quota Management**: Control resource usage with configurable limits for AI analysis, job searches, and search runs
- **Admin Capabilities**: Enable admins to have unlimited access in cloud mode while regular users have quotas
- **Database-driven Configuration**: Move from hardcoded limits to flexible, database-managed quota settings

Key improvements:
- Users can now save preferred skills, job types, locations, seniority levels, and work modes
- Quota system tracks AI analysis usage (monthly), job search results (daily), and search runs (daily)
- Admin users get unlimited quotas in cloud mode
- All quota limits are configurable via database instead of hardcoded values
- Efficient role-based access without redundant database calls

## ✅ How was this tested?

- [x] Tested locally
- [x] All tests pass
- [x] Manually verified the change works as expected
