### PR TITLE
feat: Replace Chrome Web Store links with direct GitHub release downloads

### DIFF
--- a/internal/common/github/cache.go
+++ b/internal/common/github/cache.go
@@ -1,0 +1,92 @@
+package github
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// releaseCache provides caching for GitHub release information
+type releaseCache struct {
+	client      *client
+	mu          sync.RWMutex
+	release     *release
+	lastFetch   time.Time
+	ttl         time.Duration
+	fallbackURL string
+}
+
+// newReleaseCache creates a new release cache with specified TTL
+func newReleaseCache(ttl time.Duration, fallbackURL string) *releaseCache {
+	return &releaseCache{
+		client:      newClient(),
+		ttl:         ttl,
+		fallbackURL: fallbackURL,
+	}
+}
+
+// getLatestRelease returns cached release or fetches new one if cache expired
+func (rc *releaseCache) getLatestRelease(ctx context.Context, owner, repo string) *release {
+	rc.mu.RLock()
+	if rc.release != nil && time.Since(rc.lastFetch) < rc.ttl {
+		release := rc.release
+		rc.mu.RUnlock()
+		return release
+	}
+	rc.mu.RUnlock()
+
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+
+	if rc.release != nil && time.Since(rc.lastFetch) < rc.ttl {
+		return rc.release
+	}
+
+	release, err := rc.client.getLatestRelease(ctx, owner, repo)
+	if err != nil {
+		log.Error().Err(err).
+			Str("owner", owner).
+			Str("repo", repo).
+			Msg("Failed to fetch latest release from GitHub")
+
+		if rc.release != nil {
+			log.Debug().Msg("Returning stale cached release due to fetch error")
+			return rc.release
+		}
+
+		return nil
+	}
+
+	rc.release = release
+	rc.lastFetch = time.Now()
+
+	return release
+}
+
+// getDownloadURL returns the download URL for the extension ZIP file
+func (rc *releaseCache) getDownloadURL(ctx context.Context, owner, repo string) string {
+	release := rc.getLatestRelease(ctx, owner, repo)
+
+	if release == nil {
+		log.Debug().Msg("No release available, returning fallback URL")
+		return rc.fallbackURL
+	}
+
+	zipURL := release.getZipAssetURL()
+	if zipURL == "" {
+		log.Debug().Msg("No ZIP asset found in release, returning fallback URL")
+		return rc.fallbackURL
+	}
+
+	return zipURL
+}
+
+// clearCache forces a cache refresh on next request
+func (rc *releaseCache) clearCache() {
+	rc.mu.Lock()
+	defer rc.mu.Unlock()
+	rc.release = nil
+	rc.lastFetch = time.Time{}
+}

--- a/internal/common/github/cache_test.go
+++ b/internal/common/github/cache_test.go
@@ -1,0 +1,164 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReleaseCache_GetLatestRelease(t *testing.T) {
+	var apiCalls int
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		apiCalls++
+		mu.Unlock()
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+			"tag_name": "v1.0.0",
+			"name": "Release 1.0.0",
+			"html_url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+			"assets": [
+				{
+					"name": "extension.zip",
+					"browser_download_url": "https://github.com/owner/repo/releases/download/v1.0.0/extension.zip"
+				}
+			]
+		}`))
+	}))
+	defer server.Close()
+
+	cache := &releaseCache{
+		client: &client{
+			httpClient: &http.Client{Timeout: 10 * time.Second},
+			baseURL:    server.URL,
+		},
+		ttl:         100 * time.Millisecond,
+		fallbackURL: "https://fallback.url",
+	}
+
+	ctx := context.Background()
+
+	release1 := cache.getLatestRelease(ctx, "owner", "repo")
+	require.NotNil(t, release1, "Expected non-nil release on first call")
+	assert.Equal(t, 1, apiCalls, "Expected 1 API call")
+
+	release2 := cache.getLatestRelease(ctx, "owner", "repo")
+	require.NotNil(t, release2, "Expected non-nil release on second call")
+	assert.Equal(t, 1, apiCalls, "Expected still 1 API call (cached)")
+
+	time.Sleep(150 * time.Millisecond)
+
+	release3 := cache.getLatestRelease(ctx, "owner", "repo")
+	require.NotNil(t, release3, "Expected non-nil release on third call")
+	assert.Equal(t, 2, apiCalls, "Expected 2 API calls (cache expired)")
+}
+
+func TestReleaseCache_GetDownloadURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseCode int
+		responseBody string
+		expectedURL  string
+	}{
+		{
+			name:         "successful with zip asset",
+			responseCode: http.StatusOK,
+			responseBody: `{
+				"tag_name": "v1.0.0",
+				"assets": [
+					{
+						"name": "extension.zip",
+						"browser_download_url": "https://github.com/download/extension.zip"
+					}
+				]
+			}`,
+			expectedURL: "https://github.com/download/extension.zip",
+		},
+		{
+			name:         "successful without zip asset",
+			responseCode: http.StatusOK,
+			responseBody: `{
+				"tag_name": "v1.0.0",
+				"assets": [
+					{
+						"name": "readme.txt",
+						"browser_download_url": "https://github.com/download/readme.txt"
+					}
+				]
+			}`,
+			expectedURL: "https://fallback.url",
+		},
+		{
+			name:         "no releases",
+			responseCode: http.StatusNotFound,
+			responseBody: `{"message": "Not Found"}`,
+			expectedURL:  "https://fallback.url",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.responseCode)
+				w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			cache := &releaseCache{
+				client: &client{
+					httpClient: &http.Client{Timeout: 10 * time.Second},
+					baseURL:    server.URL,
+				},
+				ttl:         1 * time.Hour,
+				fallbackURL: "https://fallback.url",
+			}
+
+			ctx := context.Background()
+			url := cache.getDownloadURL(ctx, "owner", "repo")
+
+			assert.Equal(t, tt.expectedURL, url, "URL mismatch")
+		})
+	}
+}
+
+func TestReleaseCache_ClearCache(t *testing.T) {
+	var apiCalls int
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls++
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"tag_name": "v1.0.0"}`))
+	}))
+	defer server.Close()
+
+	cache := &releaseCache{
+		client: &client{
+			httpClient: &http.Client{Timeout: 10 * time.Second},
+			baseURL:    server.URL,
+		},
+		ttl:         1 * time.Hour,
+		fallbackURL: "https://fallback.url",
+	}
+
+	ctx := context.Background()
+
+	cache.getLatestRelease(ctx, "owner", "repo")
+	assert.Equal(t, 1, apiCalls, "Expected 1 API call")
+
+	cache.getLatestRelease(ctx, "owner", "repo")
+	assert.Equal(t, 1, apiCalls, "Expected still 1 API call (cached)")
+
+	cache.clearCache()
+
+	cache.getLatestRelease(ctx, "owner", "repo")
+	assert.Equal(t, 2, apiCalls, "Expected 2 API calls (cache cleared)")
+}

--- a/internal/common/github/client.go
+++ b/internal/common/github/client.go
@@ -1,0 +1,87 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// releaseAsset represents a GitHub release asset
+type releaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// release represents a GitHub release
+type release struct {
+	Assets []releaseAsset `json:"assets"`
+}
+
+// client provides methods to interact with GitHub API
+type client struct {
+	httpClient *http.Client
+	baseURL    string
+}
+
+// newClient creates a new GitHub API client
+func newClient() *client {
+	return &client{
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+		baseURL: "https://api.github.com",
+	}
+}
+
+// getLatestRelease fetches the latest release for a given repository
+func (c *client) getLatestRelease(ctx context.Context, owner, repo string) (*release, error) {
+	url := fmt.Sprintf("%s/repos/%s/%s/releases/latest", c.baseURL, owner, repo)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", "Vega-AI-Application")
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			log.Debug().Msg("No releases found for repository")
+			return nil, nil
+		}
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	var rel release
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+
+	return &rel, nil
+}
+
+// getZipAssetURL returns the download URL for a .zip asset from a release
+func (r *release) getZipAssetURL() string {
+	if r == nil {
+		return ""
+	}
+
+	for _, asset := range r.Assets {
+		if len(asset.Name) > 4 && asset.Name[len(asset.Name)-4:] == ".zip" {
+			return asset.BrowserDownloadURL
+		}
+	}
+
+	return ""
+}

--- a/internal/common/github/client_test.go
+++ b/internal/common/github/client_test.go
@@ -1,0 +1,139 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_GetLatestRelease(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseCode   int
+		responseBody   string
+		expectedError  bool
+		expectedNil    bool
+		expectedAssets int
+	}{
+		{
+			name:         "successful response",
+			responseCode: http.StatusOK,
+			responseBody: `{
+				"tag_name": "v1.0.0",
+				"name": "Release 1.0.0",
+				"html_url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+				"assets": [
+					{
+						"name": "extension.zip",
+						"browser_download_url": "https://github.com/owner/repo/releases/download/v1.0.0/extension.zip"
+					}
+				]
+			}`,
+			expectedError:  false,
+			expectedNil:    false,
+			expectedAssets: 1,
+		},
+		{
+			name:          "no releases found",
+			responseCode:  http.StatusNotFound,
+			responseBody:  `{"message": "Not Found"}`,
+			expectedError: false,
+			expectedNil:   true,
+		},
+		{
+			name:          "server error",
+			responseCode:  http.StatusInternalServerError,
+			responseBody:  `{"message": "Internal Server Error"}`,
+			expectedError: true,
+			expectedNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method, "Expected GET request")
+				assert.NotEmpty(t, r.Header.Get("User-Agent"), "User-Agent header not set")
+
+				w.WriteHeader(tt.responseCode)
+				w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			client := &client{
+				httpClient: &http.Client{Timeout: 10 * time.Second},
+				baseURL:    server.URL,
+			}
+
+			ctx := context.Background()
+			release, err := client.getLatestRelease(ctx, "owner", "repo")
+
+			if tt.expectedError {
+				assert.Error(t, err, "Expected error but got none")
+			} else {
+				assert.NoError(t, err, "Unexpected error")
+			}
+
+			if tt.expectedNil {
+				assert.Nil(t, release, "Expected nil release")
+			} else {
+				assert.NotNil(t, release, "Expected non-nil release")
+			}
+
+			if release != nil {
+				assert.Equal(t, tt.expectedAssets, len(release.Assets), "Assets count mismatch")
+			}
+		})
+	}
+}
+
+func TestRelease_GetZipAssetURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		release     *release
+		expectedURL string
+	}{
+		{
+			name:        "nil release",
+			release:     nil,
+			expectedURL: "",
+		},
+		{
+			name: "release with zip asset",
+			release: &release{
+				Assets: []releaseAsset{
+					{Name: "file.txt", BrowserDownloadURL: "https://example.com/file.txt"},
+					{Name: "extension.zip", BrowserDownloadURL: "https://example.com/extension.zip"},
+					{Name: "readme.md", BrowserDownloadURL: "https://example.com/readme.md"},
+				},
+			},
+			expectedURL: "https://example.com/extension.zip",
+		},
+		{
+			name: "release without zip asset",
+			release: &release{
+				Assets: []releaseAsset{
+					{Name: "file.txt", BrowserDownloadURL: "https://example.com/file.txt"},
+					{Name: "readme.md", BrowserDownloadURL: "https://example.com/readme.md"},
+				},
+			},
+			expectedURL: "",
+		},
+		{
+			name:        "release with no assets",
+			release:     &release{Assets: []releaseAsset{}},
+			expectedURL: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := tt.release.getZipAssetURL()
+			assert.Equal(t, tt.expectedURL, url, "URL mismatch")
+		})
+	}
+}

--- a/internal/common/github/extension.go
+++ b/internal/common/github/extension.go
@@ -1,0 +1,35 @@
+package github
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+var (
+	extensionCache     *releaseCache
+	extensionCacheOnce sync.Once
+)
+
+const (
+	extensionOwner = "benidevo"
+	extensionRepo  = "vega-ai-extension"
+
+	extensionCacheTTL = 15 * time.Minute
+	// ExtensionFallbackURL is exported as it's used by the pages package for comparison
+	ExtensionFallbackURL = "https://github.com/benidevo/vega-ai-extension/releases/latest"
+)
+
+// getExtensionReleaseCache returns the singleton extension release cache
+func getExtensionReleaseCache() *releaseCache {
+	extensionCacheOnce.Do(func() {
+		extensionCache = newReleaseCache(extensionCacheTTL, ExtensionFallbackURL)
+	})
+	return extensionCache
+}
+
+// GetExtensionDownloadURL returns the direct download URL for the extension
+func GetExtensionDownloadURL(ctx context.Context) string {
+	cache := getExtensionReleaseCache()
+	return cache.getDownloadURL(ctx, extensionOwner, extensionRepo)
+}

--- a/internal/home/handlers.go
+++ b/internal/home/handlers.go
@@ -32,8 +32,9 @@ func (h *Handler) GetHomePage(c *gin.Context) {
 	// In cloud mode, show landing page only for "/" route
 	if h.cfg.IsCloudMode && c.Request.URL.Path == "/" {
 		username, _ := c.Get("username")
+
 		h.renderer.HTML(c, http.StatusOK, "landing/index.html", gin.H{
-			"title":    "Vega AI - AI-Powered Job Search Assistant",
+			"title":    "Vega AI-Powered Job Search Assistant",
 			"username": username,
 		})
 		return
@@ -66,7 +67,6 @@ func (h *Handler) GetHomePage(c *gin.Context) {
 		}
 	}
 
-	// Create context with role for quota checking
 	ctx := c.Request.Context()
 	if roleValue, exists := c.Get("role"); exists {
 		if role, ok := roleValue.(string); ok {

--- a/internal/pages/extension.go
+++ b/internal/pages/extension.go
@@ -1,0 +1,38 @@
+package pages
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/benidevo/vega/internal/common/github"
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+)
+
+// GetExtensionDownload redirects to the latest extension download URL
+func (h *Handler) GetExtensionDownload(c *gin.Context) {
+	downloadURL := github.GetExtensionDownloadURL(c.Request.Context())
+
+	if downloadURL != "" && downloadURL != github.ExtensionFallbackURL {
+		// Validate the URL is from GitHub to prevent open redirect
+		u, err := url.Parse(downloadURL)
+		if err != nil {
+			log.Warn().Err(err).Str("url", downloadURL).Msg("Invalid download URL")
+			c.Redirect(http.StatusTemporaryRedirect, github.ExtensionFallbackURL)
+			return
+		}
+
+		// Ensure the host is github.com or a GitHub subdomain
+		if !strings.HasSuffix(u.Host, "github.com") && !strings.HasSuffix(u.Host, "githubusercontent.com") {
+			log.Warn().Str("url", downloadURL).Str("host", u.Host).Msg("Download URL not from GitHub")
+			c.Redirect(http.StatusTemporaryRedirect, github.ExtensionFallbackURL)
+			return
+		}
+
+		c.Redirect(http.StatusTemporaryRedirect, downloadURL)
+		return
+	}
+
+	c.Redirect(http.StatusTemporaryRedirect, github.ExtensionFallbackURL)
+}

--- a/internal/vega/routes.go
+++ b/internal/vega/routes.go
@@ -104,9 +104,10 @@ func SetupRoutes(a *App) {
 	jobAPIGroup.Use(authHandler.APIAuthMiddleware())
 	jobapi.RegisterRoutes(jobAPIGroup, jobAPIHandler)
 
+	pagesHandler := pages.NewHandler(&a.config)
 	if a.config.IsCloudMode {
-		pagesHandler := pages.NewHandler(&a.config)
 		a.router.GET("/privacy", pagesHandler.GetPrivacyPage)
+		a.router.GET("/extension/download", pagesHandler.GetExtensionDownload)
 	}
 
 	a.router.NoRoute(func(c *gin.Context) {

--- a/templates/landing/partials/faq.html
+++ b/templates/landing/partials/faq.html
@@ -48,7 +48,7 @@
               </svg>
             </summary>
             <div class="px-4 sm:px-6 pb-4 sm:pb-6">
-              <p class="text-gray-300 text-sm sm:text-base">Yes! The browser extension works with both cloud and local modes. It saves jobs from LinkedIn with one click. Support for Glassdoor and Indeed coming soon. Compatible with Chrome and Edge browsers. <a href="https://chromewebstore.google.com/detail/vega-ai-job-capture/oboedhpojbjemdmojfchifppbgbfehol" target="_blank" rel="noopener" class="text-primary hover:text-primary-dark underline">Get it from the Chrome Web Store</a>.</p>
+              <p class="text-gray-300 text-sm sm:text-base">Yes! The browser extension works with both cloud and local modes. It saves jobs from LinkedIn with one click. Support for Glassdoor and Indeed coming soon. Compatible with Chrome and Edge browsers. <a href="/extension/download" rel="noopener" class="text-primary hover:text-primary-dark underline">Download the extension</a>.</p>
             </div>
           </details>
 

--- a/templates/landing/partials/features.html
+++ b/templates/landing/partials/features.html
@@ -51,7 +51,7 @@
               </div>
             </div>
             <h3 class="text-lg sm:text-xl font-semibold text-white mb-3 group-hover:text-primary transition-colors">Browser Extension</h3>
-            <p class="text-sm sm:text-base text-gray-400 leading-relaxed">Save jobs from LinkedIn with one click. Glassdoor and Indeed coming soon. <a href="https://chromewebstore.google.com/detail/vega-ai-job-capture/oboedhpojbjemdmojfchifppbgbfehol" target="_blank" rel="noopener" class="text-primary hover:text-primary-dark underline">Get it from Chrome Web Store</a>.</p>
+            <p class="text-sm sm:text-base text-gray-400 leading-relaxed">Save jobs from LinkedIn with one click. Glassdoor and Indeed coming soon. <a href="/extension/download" rel="noopener" class="text-primary hover:text-primary-dark underline">Download the extension</a>.</p>
           </div>
         </div>
       </div>

--- a/templates/landing/partials/get-started.html
+++ b/templates/landing/partials/get-started.html
@@ -211,18 +211,25 @@
               <div class="pl-0 sm:pl-13">
                 <p class="text-gray-400 text-sm mb-3">Add the browser extension for one-click job capture from LinkedIn:</p>
                 <div class="space-y-3">
-                  <div>
-                    <p class="text-sm text-gray-300 mb-2 font-semibold">Easy Installation:</p>
-                    <a href="https://chromewebstore.google.com/detail/vega-ai-job-capture/oboedhpojbjemdmojfchifppbgbfehol" class="inline-block bg-primary hover:bg-primary-dark text-white px-4 py-2 rounded-lg text-xs sm:text-sm font-medium transition-colors text-center" target="_blank" rel="noopener">
-                      Get Extension
+                  <div id="extension-download-section">
+                    <p class="text-sm text-gray-300 mb-2 font-semibold">Direct Download:</p>
+                    <a href="/extension/download" class="inline-block bg-primary hover:bg-primary-dark text-white px-4 py-2 rounded-lg text-xs sm:text-sm font-medium transition-colors text-center" rel="noopener">
+                      Download Extension
                     </a>
+
+                    {{/* Link to view all releases */}}
+                    <p class="text-xs text-gray-500 mt-2">
+                      <a href="https://github.com/benidevo/vega-ai-extension/releases" class="text-primary hover:text-primary-dark transition-colors" target="_blank" rel="noopener">
+                        View all releases
+                      </a>
+                    </p>
                   </div>
                   <div>
-                    <p class="text-sm text-gray-300 mb-2 font-semibold">Manual Installation:</p>
+                    <p class="text-sm text-gray-300 mb-2 font-semibold">Installation Instructions:</p>
                     <ol class="space-y-1 text-xs sm:text-sm text-gray-400">
                       <li class="flex items-start">
                         <span class="text-primary font-medium mr-2 flex-shrink-0">a.</span>
-                        <span><a href="https://github.com/benidevo/vega-ai-extension/releases/latest" class="text-primary hover:text-primary-dark transition-colors" target="_blank" rel="noopener">Download the latest extension</a> (.zip file)</span>
+                        <span>Download and extract the extension ZIP file</span>
                       </li>
                       <li class="flex items-start">
                         <span class="text-primary font-medium mr-2 flex-shrink-0">b.</span>


### PR DESCRIPTION
## 🚀 What's this about?

This PR replaces all Chrome Web Store links on the landing page with direct download links from GitHub releases. The implementation fetches the latest extension release dynamically from the GitHub API and provides a direct download link to users without requiring them to navigate to GitHub.

### Key Changes

- **GitHub API Integration**: New `github` package that fetches latest releases from the GitHub API
- **Intelligent Caching**: 15-minute TTL cache to minimize API calls (max 4 requests/hour)
- **Security Hardening**: URL validation to prevent open redirect vulnerabilities
- **Smart Routing**: Extension download route only available in cloud mode where it's needed


## 💡 Why this matters

**Problem**: The Chrome Web Store link was hardcoded in multiple places across the landing page, making updates difficult and providing no control over the distribution process.

**Solution**: This change provides:

1. **Better Control**: Direct distribution from GitHub releases without Chrome Web Store dependency
2. **Always Current**: Users always get the latest version automatically
3. **Improved Security**: Validates redirect URLs to prevent potential security issues
5. **Performance**: Caching ensures minimal API calls while keeping data fresh

## ✅ How was this tested?

- [x] Tested locally
- [x] All tests pass
- [x] Manually verified the change works as expected
- [x] Verified caching behavior (15-minute TTL)
- [x] Confirmed route only registered in cloud mode