### PR TITLE
feat: add token expiration times and verification endpoint

### DIFF
--- a/internal/api/auth/handlers.go
+++ b/internal/api/auth/handlers.go
@@ -4,68 +4,29 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/benidevo/vega/internal/auth/services"
 	"github.com/benidevo/vega/internal/common/logger"
 	"github.com/gin-gonic/gin"
 )
 
-// oauthService defines OAuth operations needed by the API handler
-type oauthService interface {
-	Authenticate(ctx context.Context, code, redirectURI string) (accessToken, refreshToken string, err error)
-}
-
-// authService defines auth operations needed by the API handler
 type authService interface {
-	Login(ctx context.Context, username, password string) (string, string, error)
-	RefreshAccessToken(ctx context.Context, refreshToken string) (string, error)
+	Login(ctx context.Context, username, password string) (string, string, int64, error)
+	RefreshAccessToken(ctx context.Context, refreshToken string) (string, string, int64, error)
+	VerifyToken(token string) (*services.Claims, error)
 }
 
-// AuthAPIHandler handles authentication-related API requests using the provided OAuth service and authentication service.
 type AuthAPIHandler struct {
-	oauthService oauthService
-	authService  authService
-	log          *logger.PrivacyLogger
+	authService authService
+	log         *logger.PrivacyLogger
 }
 
-// NewAuthAPIHandler creates and returns a new AuthAPIHandler with the provided GoogleAuthService and Authentication service.
-func NewAuthAPIHandler(oauthService oauthService, authService authService) *AuthAPIHandler {
+func NewAuthAPIHandler(authService authService) *AuthAPIHandler {
 	return &AuthAPIHandler{
-		oauthService: oauthService,
-		authService:  authService,
-		log:          logger.GetPrivacyLogger("api_auth"),
+		authService: authService,
+		log:         logger.GetPrivacyLogger("api_auth"),
 	}
 }
 
-// ExchangeTokenForJWT handles the exchange of an OAuth authorization code for a JWT access token.
-//
-// It expects a JSON body with "code" and "redirect_uri" fields, and returns the JWT token on success.
-func (h *AuthAPIHandler) ExchangeTokenForJWT(ctx *gin.Context) {
-	var request struct {
-		Code        string `json:"code" binding:"required"`
-		RedirectURI string `json:"redirect_uri" binding:"required"`
-	}
-
-	if err := ctx.ShouldBindJSON(&request); err != nil {
-		h.log.Error().Err(err).Msg("Failed to bind OAuth token exchange request body")
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
-		return
-	}
-
-	h.log.Debug().
-		Str("redirect_uri", request.RedirectURI).
-		Msg("OAuth token exchange request received")
-
-	accessToken, refreshToken, err := h.oauthService.Authenticate(ctx.Request.Context(), request.Code, request.RedirectURI)
-	if err != nil {
-		h.log.Error().Err(err).Msg("Failed to exchange OAuth code for JWT")
-		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "failed to exchange code for JWT"})
-		return
-	}
-
-	ctx.JSON(http.StatusOK, gin.H{"token": accessToken, "refresh_token": refreshToken})
-}
-
-// RefreshToken handles the token refresh request by validating the provided refresh token
-// and returning a new access token if successful.
 func (h *AuthAPIHandler) RefreshToken(ctx *gin.Context) {
 	var request struct {
 		RefreshToken string `json:"refresh_token" binding:"required"`
@@ -77,19 +38,51 @@ func (h *AuthAPIHandler) RefreshToken(ctx *gin.Context) {
 		return
 	}
 
-	accessToken, err := h.authService.RefreshAccessToken(ctx.Request.Context(), request.RefreshToken)
+	accessToken, refreshToken, expiresAt, err := h.authService.RefreshAccessToken(ctx.Request.Context(), request.RefreshToken)
 	if err != nil {
 		h.log.Debug().Err(err).Msg("Failed to refresh access token")
 		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "failed to refresh access token"})
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{"token": accessToken})
+	ctx.JSON(http.StatusOK, gin.H{"token": accessToken, "refresh_token": refreshToken, "expires_at": expiresAt})
 }
 
-// Login handles user login requests. It expects a JSON payload containing a username and password.
-//
-// On successful authentication, it returns an access token and a refresh token in the response body.
+func (h *AuthAPIHandler) VerifyToken(ctx *gin.Context) {
+	authHeader := ctx.GetHeader("Authorization")
+	if authHeader == "" {
+		h.log.Debug().Msg("Missing Authorization header")
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "missing authorization header"})
+		return
+	}
+
+	const bearerPrefix = "Bearer "
+	if len(authHeader) < len(bearerPrefix) || authHeader[:len(bearerPrefix)] != bearerPrefix {
+		h.log.Debug().Msg("Invalid Authorization header format")
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid authorization header format"})
+		return
+	}
+
+	token := authHeader[len(bearerPrefix):]
+	claims, err := h.authService.VerifyToken(token)
+	if err != nil {
+		h.log.Debug().Err(err).Msg("Token verification failed")
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
+		return
+	}
+	h.log.Debug().
+		Int("user_id", claims.UserID).
+		Str("username", claims.Username).
+		Msg("Token verified successfully")
+
+	ctx.JSON(http.StatusOK, gin.H{
+		"valid":    true,
+		"user_id":  claims.UserID,
+		"username": claims.Username,
+		"role":     claims.Role,
+	})
+}
+
 func (h *AuthAPIHandler) Login(ctx *gin.Context) {
 	var request struct {
 		Username string `json:"username" binding:"required"`
@@ -102,7 +95,7 @@ func (h *AuthAPIHandler) Login(ctx *gin.Context) {
 		return
 	}
 
-	accessToken, refreshToken, err := h.authService.Login(ctx.Request.Context(), request.Username, request.Password)
+	accessToken, refreshToken, expiresAt, err := h.authService.Login(ctx.Request.Context(), request.Username, request.Password)
 	if err != nil {
 		h.log.Debug().
 			Err(err).
@@ -112,5 +105,5 @@ func (h *AuthAPIHandler) Login(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{"token": accessToken, "refresh_token": refreshToken})
+	ctx.JSON(http.StatusOK, gin.H{"token": accessToken, "refresh_token": refreshToken, "expires_at": expiresAt})
 }

--- a/internal/api/auth/handlers_test.go
+++ b/internal/api/auth/handlers_test.go
@@ -8,145 +8,46 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/benidevo/vega/internal/auth/services"
 	"github.com/benidevo/vega/internal/common/testutil"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-// mockOAuthService implements the oauthService interface for testing
-type mockOAuthService struct {
-	mock.Mock
-}
-
-func (m *mockOAuthService) Authenticate(ctx context.Context, code, redirectURI string) (string, string, error) {
-	args := m.Called(ctx, code, redirectURI)
-	return args.String(0), args.String(1), args.Error(2)
-}
-
-// mockAuthService implements the authService interface for testing
 type mockAuthService struct {
 	mock.Mock
 }
 
-func (m *mockAuthService) Login(ctx context.Context, username, password string) (string, string, error) {
+func (m *mockAuthService) Login(ctx context.Context, username, password string) (string, string, int64, error) {
 	args := m.Called(ctx, username, password)
-	return args.String(0), args.String(1), args.Error(2)
+	return args.String(0), args.String(1), args.Get(2).(int64), args.Error(3)
 }
 
-func (m *mockAuthService) RefreshAccessToken(ctx context.Context, refreshToken string) (string, error) {
+func (m *mockAuthService) RefreshAccessToken(ctx context.Context, refreshToken string) (string, string, int64, error) {
 	args := m.Called(ctx, refreshToken)
-	return args.String(0), args.Error(1)
+	return args.String(0), args.String(1), args.Get(2).(int64), args.Error(3)
 }
 
-func setupTestAuthAPIHandler() (*AuthAPIHandler, *mockOAuthService, *mockAuthService, *gin.Engine) {
-	mockOAuth := new(mockOAuthService)
+func (m *mockAuthService) VerifyToken(token string) (*services.Claims, error) {
+	args := m.Called(token)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*services.Claims), args.Error(1)
+}
+
+func setupTestAuthAPIHandler() (*AuthAPIHandler, *mockAuthService, *gin.Engine) {
 	mockAuth := new(mockAuthService)
 
-	handler := NewAuthAPIHandler(mockOAuth, mockAuth)
+	handler := NewAuthAPIHandler(mockAuth)
 	router := testutil.SetupTestRouter()
 
-	return handler, mockOAuth, mockAuth, router
-}
-
-func TestAuthAPIHandler_ExchangeTokenForJWT(t *testing.T) {
-	handler, mockOAuth, _, router := setupTestAuthAPIHandler()
-
-	// Setup routes
-	router.POST("/api/auth/token", handler.ExchangeTokenForJWT)
-
-	tests := []testutil.HandlerTestCase{
-		{
-			Name:   "should_exchange_oauth_code_when_valid",
-			Method: "POST",
-			Path:   "/api/auth/token",
-			Body: map[string]string{
-				"code":         "valid-oauth-code",
-				"redirect_uri": "http://localhost:3000/callback",
-			},
-			Headers: map[string]string{
-				"Content-Type": "application/json",
-			},
-			MockSetup: func() {
-				mockOAuth.On("Authenticate", mock.Anything, "valid-oauth-code", "http://localhost:3000/callback").
-					Return("access-token", "refresh-token", nil)
-			},
-			ExpectedStatus: http.StatusOK,
-			ValidateBody: func(t *testing.T, w *httptest.ResponseRecorder) {
-				var response map[string]interface{}
-				err := json.Unmarshal(w.Body.Bytes(), &response)
-				assert.NoError(t, err)
-				assert.Equal(t, "access-token", response["token"])
-				assert.Equal(t, "refresh-token", response["refresh_token"])
-			},
-		},
-		{
-			Name:   "should_return_unauthorized_when_invalid_code",
-			Method: "POST",
-			Path:   "/api/auth/token",
-			Body: map[string]string{
-				"code":         "invalid-oauth-code",
-				"redirect_uri": "http://localhost:3000/callback",
-			},
-			Headers: map[string]string{
-				"Content-Type": "application/json",
-			},
-			MockSetup: func() {
-				mockOAuth.On("Authenticate", mock.Anything, "invalid-oauth-code", "http://localhost:3000/callback").
-					Return("", "", errors.New("invalid authorization code"))
-			},
-			ExpectedStatus: http.StatusUnauthorized,
-			ValidateBody: func(t *testing.T, w *httptest.ResponseRecorder) {
-				var response map[string]string
-				err := json.Unmarshal(w.Body.Bytes(), &response)
-				assert.NoError(t, err)
-				assert.Equal(t, "failed to exchange code for JWT", response["error"])
-			},
-		},
-		{
-			Name:   "should_return_bad_request_when_missing_required_fields",
-			Method: "POST",
-			Path:   "/api/auth/token",
-			Body:   map[string]string{},
-			Headers: map[string]string{
-				"Content-Type": "application/json",
-			},
-			ExpectedStatus: http.StatusBadRequest,
-			ValidateBody: func(t *testing.T, w *httptest.ResponseRecorder) {
-				var response map[string]string
-				err := json.Unmarshal(w.Body.Bytes(), &response)
-				assert.NoError(t, err)
-				assert.Equal(t, "invalid request body", response["error"])
-			},
-		},
-		{
-			Name:           "should_return_bad_request_when_invalid_json",
-			Method:         "POST",
-			Path:           "/api/auth/token",
-			Body:           "invalid-json",
-			Headers:        map[string]string{"Content-Type": "application/json"},
-			ExpectedStatus: http.StatusBadRequest,
-			ValidateBody: func(t *testing.T, w *httptest.ResponseRecorder) {
-				var response map[string]string
-				err := json.Unmarshal(w.Body.Bytes(), &response)
-				assert.NoError(t, err)
-				assert.Equal(t, "invalid request body", response["error"])
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.Name, func(t *testing.T) {
-			mockOAuth.ExpectedCalls = nil
-			mockOAuth.Calls = nil
-			testutil.RunHandlerTest(t, router, tc)
-			mockOAuth.AssertExpectations(t)
-		})
-	}
+	return handler, mockAuth, router
 }
 
 func TestAuthAPIHandler_RefreshToken(t *testing.T) {
-	handler, _, mockAuth, router := setupTestAuthAPIHandler()
+	handler, mockAuth, router := setupTestAuthAPIHandler()
 
 	// Setup routes
 	router.POST("/api/auth/refresh", handler.RefreshToken)
@@ -164,7 +65,7 @@ func TestAuthAPIHandler_RefreshToken(t *testing.T) {
 			},
 			MockSetup: func() {
 				mockAuth.On("RefreshAccessToken", mock.Anything, "valid-refresh-token").
-					Return("new-access-token", nil)
+					Return("new-access-token", "new-refresh-token", int64(1234567890), nil)
 			},
 			ExpectedStatus: http.StatusOK,
 			ValidateBody: func(t *testing.T, w *httptest.ResponseRecorder) {
@@ -172,6 +73,8 @@ func TestAuthAPIHandler_RefreshToken(t *testing.T) {
 				err := json.Unmarshal(w.Body.Bytes(), &response)
 				assert.NoError(t, err)
 				assert.Equal(t, "new-access-token", response["token"])
+				assert.Equal(t, "new-refresh-token", response["refresh_token"])
+				assert.Equal(t, float64(1234567890), response["expires_at"])
 			},
 		},
 		{
@@ -186,7 +89,7 @@ func TestAuthAPIHandler_RefreshToken(t *testing.T) {
 			},
 			MockSetup: func() {
 				mockAuth.On("RefreshAccessToken", mock.Anything, "invalid-refresh-token").
-					Return("", errors.New("invalid token"))
+					Return("", "", int64(0), errors.New("invalid token"))
 			},
 			ExpectedStatus: http.StatusUnauthorized,
 			ValidateBody: func(t *testing.T, w *httptest.ResponseRecorder) {
@@ -239,7 +142,7 @@ func TestAuthAPIHandler_RefreshToken(t *testing.T) {
 }
 
 func TestAuthAPIHandler_Login(t *testing.T) {
-	handler, _, mockAuth, router := setupTestAuthAPIHandler()
+	handler, mockAuth, router := setupTestAuthAPIHandler()
 
 	// Setup routes
 	router.POST("/api/auth/login", handler.Login)
@@ -258,7 +161,7 @@ func TestAuthAPIHandler_Login(t *testing.T) {
 			},
 			MockSetup: func() {
 				mockAuth.On("Login", mock.Anything, "testuser", "password123").
-					Return("access-token", "refresh-token", nil)
+					Return("access-token", "refresh-token", int64(1234567890), nil)
 			},
 			ExpectedStatus: http.StatusOK,
 			ValidateBody: func(t *testing.T, w *httptest.ResponseRecorder) {
@@ -267,6 +170,7 @@ func TestAuthAPIHandler_Login(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, "access-token", response["token"])
 				assert.Equal(t, "refresh-token", response["refresh_token"])
+				assert.Equal(t, float64(1234567890), response["expires_at"])
 			},
 		},
 		{
@@ -282,7 +186,7 @@ func TestAuthAPIHandler_Login(t *testing.T) {
 			},
 			MockSetup: func() {
 				mockAuth.On("Login", mock.Anything, "testuser", "wrongpassword").
-					Return("", "", errors.New("invalid credentials"))
+					Return("", "", int64(0), errors.New("invalid credentials"))
 			},
 			ExpectedStatus: http.StatusUnauthorized,
 			ValidateBody: func(t *testing.T, w *httptest.ResponseRecorder) {

--- a/internal/api/auth/routes.go
+++ b/internal/api/auth/routes.go
@@ -2,9 +2,8 @@ package auth
 
 import "github.com/gin-gonic/gin"
 
-// RegisterRoutes registers API authentication-related routes to the provided Gin router group.
 func RegisterRoutes(router *gin.RouterGroup, handler *AuthAPIHandler) {
-	router.POST("/google", handler.ExchangeTokenForJWT)
 	router.POST("/refresh", handler.RefreshToken)
 	router.POST("/login", handler.Login)
+	router.GET("/verify", handler.VerifyToken)
 }

--- a/internal/api/auth/setup.go
+++ b/internal/api/auth/setup.go
@@ -8,13 +8,8 @@ import (
 	"github.com/benidevo/vega/internal/config"
 )
 
-// Setup initializes the authentication API handler with the provided database connection and configuration settings.
 func Setup(db *sql.DB, cfg *config.Settings) *AuthAPIHandler {
 	repo := repository.NewSQLiteUserRepository(db)
-	oauthService, _ := services.NewGoogleAuthService(cfg, repo)
 	authService := services.NewAuthService(repo, cfg)
-
-	handler := NewAuthAPIHandler(oauthService, authService)
-
-	return handler
+	return NewAuthAPIHandler(authService)
 }

--- a/internal/auth/handlers.go
+++ b/internal/auth/handlers.go
@@ -14,11 +14,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// authService defines the methods AuthHandler needs from the auth service
 type authService interface {
-	Login(ctx context.Context, username, password string) (string, string, error)
+	Login(ctx context.Context, username, password string) (string, string, int64, error)
 	VerifyToken(token string) (*services.Claims, error)
-	RefreshAccessToken(ctx context.Context, refreshToken string) (string, error)
+	RefreshAccessToken(ctx context.Context, refreshToken string) (string, string, int64, error)
 	LogError(err error)
 }
 
@@ -62,7 +61,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
-	accessToken, refreshToken, loginErr := h.service.Login(c.Request.Context(), req.Username, req.Password)
+	accessToken, refreshToken, _, loginErr := h.service.Login(c.Request.Context(), req.Username, req.Password)
 	if loginErr != nil {
 		h.service.LogError(loginErr)
 		c.Header("X-Toast-Message", loginErr.Error())
@@ -114,7 +113,7 @@ func (h *AuthHandler) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	accessToken, err := h.service.RefreshAccessToken(c.Request.Context(), refreshToken)
+	accessToken, _, _, err := h.service.RefreshAccessToken(c.Request.Context(), refreshToken)
 	if err != nil {
 		h.service.LogError(fmt.Errorf("refresh token validation failed: %w", err))
 		h.clearAuthCookies(c)
@@ -161,7 +160,7 @@ func (h *AuthHandler) authMiddleware(c *gin.Context) (*services.Claims, error) {
 	if err != nil || tokenString == "" {
 		refreshToken, refreshErr := c.Cookie("refresh_token")
 		if refreshErr == nil && refreshToken != "" {
-			newAccessToken, refreshErr := h.service.RefreshAccessToken(c.Request.Context(), refreshToken)
+			newAccessToken, _, _, refreshErr := h.service.RefreshAccessToken(c.Request.Context(), refreshToken)
 			if refreshErr == nil {
 				sameSite := parseSameSiteMode(h.cfg.CookieSameSite)
 				c.SetSameSite(sameSite)
@@ -197,7 +196,7 @@ func (h *AuthHandler) authMiddleware(c *gin.Context) (*services.Claims, error) {
 		// Try to refresh with the existing refresh token
 		refreshToken, refreshErr := c.Cookie("refresh_token")
 		if refreshErr == nil && refreshToken != "" {
-			newAccessToken, refreshErr := h.service.RefreshAccessToken(c.Request.Context(), refreshToken)
+			newAccessToken, _, _, refreshErr := h.service.RefreshAccessToken(c.Request.Context(), refreshToken)
 			if refreshErr == nil {
 				sameSite := parseSameSiteMode(h.cfg.CookieSameSite)
 				c.SetSameSite(sameSite)

--- a/internal/auth/handlers_test.go
+++ b/internal/auth/handlers_test.go
@@ -19,14 +19,13 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// mockAuthService implements the authService interface for testing
 type mockAuthService struct {
 	mock.Mock
 }
 
-func (m *mockAuthService) Login(ctx context.Context, username, password string) (string, string, error) {
+func (m *mockAuthService) Login(ctx context.Context, username, password string) (string, string, int64, error) {
 	args := m.Called(ctx, username, password)
-	return args.String(0), args.String(1), args.Error(2)
+	return args.String(0), args.String(1), args.Get(2).(int64), args.Error(3)
 }
 
 func (m *mockAuthService) VerifyToken(token string) (*services.Claims, error) {
@@ -37,9 +36,9 @@ func (m *mockAuthService) VerifyToken(token string) (*services.Claims, error) {
 	return args.Get(0).(*services.Claims), args.Error(1)
 }
 
-func (m *mockAuthService) RefreshAccessToken(ctx context.Context, refreshToken string) (string, error) {
+func (m *mockAuthService) RefreshAccessToken(ctx context.Context, refreshToken string) (string, string, int64, error) {
 	args := m.Called(ctx, refreshToken)
-	return args.String(0), args.Error(1)
+	return args.String(0), args.String(1), args.Get(2).(int64), args.Error(3)
 }
 
 func (m *mockAuthService) LogError(err error) {
@@ -86,7 +85,7 @@ func TestAuthHandler_Login(t *testing.T) {
 			},
 			MockSetup: func() {
 				mockService.On("Login", mock.Anything, "testuser", "password123").
-					Return("access-token", "refresh-token", nil)
+					Return("access-token", "refresh-token", int64(1234567890), nil)
 			},
 			ExpectedStatus: http.StatusOK,
 			ExpectedHeader: map[string]string{
@@ -117,7 +116,7 @@ func TestAuthHandler_Login(t *testing.T) {
 			},
 			MockSetup: func() {
 				mockService.On("Login", mock.Anything, "testuser", "wrongpassword").
-					Return("", "", models.ErrInvalidCredentials)
+					Return("", "", int64(0), models.ErrInvalidCredentials)
 				mockService.On("LogError", models.ErrInvalidCredentials).Return()
 			},
 			ExpectedStatus: http.StatusUnauthorized,
@@ -246,7 +245,7 @@ func TestAuthHandler_RefreshToken(t *testing.T) {
 			},
 			MockSetup: func() {
 				mockService.On("RefreshAccessToken", mock.Anything, "valid-refresh-token").
-					Return("new-access-token", nil)
+					Return("new-access-token", "new-refresh-token", int64(1234567890), nil)
 			},
 			ExpectedStatus: http.StatusOK,
 			ExpectedCookie: []testutil.CookieAssertion{
@@ -273,7 +272,7 @@ func TestAuthHandler_RefreshToken(t *testing.T) {
 			},
 			MockSetup: func() {
 				mockService.On("RefreshAccessToken", mock.Anything, "invalid-refresh-token").
-					Return("", models.ErrInvalidToken)
+					Return("", "", int64(0), models.ErrInvalidToken)
 				mockService.On("LogError", mock.Anything).Return()
 			},
 			ExpectedStatus: http.StatusUnauthorized,
@@ -305,7 +304,7 @@ func TestAuthHandler_RefreshToken(t *testing.T) {
 			},
 			MockSetup: func() {
 				mockService.On("RefreshAccessToken", mock.Anything, "valid-refresh-token").
-					Return("", errors.New("service error"))
+					Return("", "", int64(0), errors.New("service error"))
 				mockService.On("LogError", mock.Anything).Return()
 			},
 			ExpectedStatus: http.StatusUnauthorized,

--- a/internal/auth/services/auth.go
+++ b/internal/auth/services/auth.go
@@ -13,7 +13,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
-// Claims represents the JWT claims for authentication, including user ID, username, role, and standard registered claims.
 type Claims struct {
 	UserID    int    `json:"user_id"`
 	Username  string `json:"username"`
@@ -22,19 +21,16 @@ type Claims struct {
 	jwt.RegisteredClaims
 }
 
-// AuthService provides authentication and user management functionality
 type AuthService struct {
 	repo   repository.UserRepository
 	config *config.Settings
 	log    *logger.PrivacyLogger
 }
 
-// NewAuthService creates and returns a new AuthService instance using the provided UserRepository and configuration settings.
 func NewAuthService(repo repository.UserRepository, config *config.Settings) *AuthService {
 	return &AuthService{repo: repo, config: config, log: logger.GetPrivacyLogger("auth")}
 }
 
-// LogError logs an authentication error using the service's logger.
 func (s *AuthService) LogError(err error) {
 	s.log.Error().Err(err).Msg("Authentication error")
 }
@@ -71,9 +67,7 @@ func (s *AuthService) Register(ctx context.Context, username, password, role str
 	return user, nil
 }
 
-// Login authenticates a user by verifying the provided username and password.
-// If successful, it generates and returns access and refresh tokens and updates the user's last login timestamp.
-func (s *AuthService) Login(ctx context.Context, username, password string) (string, string, error) {
+func (s *AuthService) Login(ctx context.Context, username, password string) (string, string, int64, error) {
 	user, err := s.repo.FindByUsername(ctx, username)
 	if err != nil {
 		sentinelErr := models.GetSentinelError(err)
@@ -89,7 +83,7 @@ func (s *AuthService) Login(ctx context.Context, username, password string) (str
 				Msg("Error retrieving user during login")
 		}
 
-		return "", "", models.ErrInvalidCredentials
+		return "", "", 0, models.ErrInvalidCredentials
 	}
 
 	if user.Password == "" {
@@ -97,12 +91,12 @@ func (s *AuthService) Login(ctx context.Context, username, password string) (str
 			Str("event", "login_oauth_account_password_attempt").
 			Str("user_ref", fmt.Sprintf("user_%d", user.ID)).
 			Msg("User password is empty. Account was created using Google authentication")
-		return "", "", models.ErrInvalidCredentials
+		return "", "", 0, models.ErrInvalidCredentials
 	}
 
 	if !verifyPassword(user.Password, password) {
 		s.log.LogAuthEvent("login_invalid_password", user.ID, false)
-		return "", "", models.ErrInvalidCredentials
+		return "", "", 0, models.ErrInvalidCredentials
 	}
 
 	accessToken, err := GenerateAccessToken(user, s.config)
@@ -111,7 +105,7 @@ func (s *AuthService) Login(ctx context.Context, username, password string) (str
 			Str("event", "access_token_generation_failed").
 			Str("user_ref", fmt.Sprintf("user_%d", user.ID)).
 			Msg("Failed to generate access token")
-		return "", "", models.ErrInvalidCredentials
+		return "", "", 0, models.ErrInvalidCredentials
 	}
 
 	refreshToken, err := GenerateRefreshToken(user, s.config)
@@ -120,8 +114,9 @@ func (s *AuthService) Login(ctx context.Context, username, password string) (str
 			Str("event", "refresh_token_generation_failed").
 			Str("user_ref", fmt.Sprintf("user_%d", user.ID)).
 			Msg("Failed to generate refresh token")
-		return "", "", models.ErrInvalidCredentials
+		return "", "", 0, models.ErrInvalidCredentials
 	}
+	expiresAt := time.Now().UTC().Add(s.config.AccessTokenExpiry).Unix()
 
 	user.LastLogin = time.Now().UTC()
 	_, err = s.repo.UpdateUser(ctx, user)
@@ -135,20 +130,19 @@ func (s *AuthService) Login(ctx context.Context, username, password string) (str
 	}
 
 	s.log.LogAuthEvent("login_success", user.ID, true)
-	return accessToken, refreshToken, nil
+	return accessToken, refreshToken, expiresAt, nil
 }
 
-// RefreshAccessToken validates a refresh token and generates a new access token if valid
-func (s *AuthService) RefreshAccessToken(ctx context.Context, refreshToken string) (string, error) {
+func (s *AuthService) RefreshAccessToken(ctx context.Context, refreshToken string) (string, string, int64, error) {
 	claims, err := s.VerifyToken(refreshToken)
 	if err != nil {
 		s.log.Error().Err(err).Msg("Invalid refresh token")
-		return "", models.ErrInvalidToken
+		return "", "", 0, models.ErrInvalidToken
 	}
 
 	if claims.TokenType != "refresh" {
 		s.log.Error().Msg("Token provided is not a refresh token")
-		return "", models.ErrInvalidToken
+		return "", "", 0, models.ErrInvalidToken
 	}
 
 	user, err := s.repo.FindByID(ctx, claims.UserID)
@@ -159,7 +153,7 @@ func (s *AuthService) RefreshAccessToken(ctx context.Context, refreshToken strin
 			Str("user_ref", fmt.Sprintf("user_%d", claims.UserID)).
 			Str("error_type", sentinelErr.Error()).
 			Msg("Failed to find user for token refresh")
-		return "", models.ErrInvalidToken
+		return "", "", 0, models.ErrInvalidToken
 	}
 
 	if user == nil {
@@ -167,7 +161,7 @@ func (s *AuthService) RefreshAccessToken(ctx context.Context, refreshToken strin
 			Str("event", "token_refresh_user_nil").
 			Str("user_ref", fmt.Sprintf("user_%d", claims.UserID)).
 			Msg("User not found for token refresh")
-		return "", models.ErrInvalidToken
+		return "", "", 0, models.ErrInvalidToken
 	}
 
 	accessToken, err := GenerateAccessToken(user, s.config)
@@ -176,17 +170,25 @@ func (s *AuthService) RefreshAccessToken(ctx context.Context, refreshToken strin
 			Str("event", "token_refresh_failed").
 			Str("user_ref", fmt.Sprintf("user_%d", user.ID)).
 			Msg("Failed to generate new access token")
-		return "", models.ErrTokenCreationFailed
+		return "", "", 0, models.ErrTokenCreationFailed
 	}
+	newRefreshToken, err := GenerateRefreshToken(user, s.config)
+	if err != nil {
+		s.log.Error().Err(err).
+			Str("event", "refresh_token_rotation_failed").
+			Str("user_ref", fmt.Sprintf("user_%d", user.ID)).
+			Msg("Failed to generate new refresh token")
+		newRefreshToken = refreshToken
+	}
+	expiresAt := time.Now().UTC().Add(s.config.AccessTokenExpiry).Unix()
 
 	s.log.Info().
 		Str("event", "token_refreshed").
 		Str("user_ref", fmt.Sprintf("user_%d", user.ID)).
 		Msg("Access token refreshed successfully")
-	return accessToken, nil
+	return accessToken, newRefreshToken, expiresAt, nil
 }
 
-// GetUserByID retrieves a user by their unique ID from the repository.
 func (s *AuthService) GetUserByID(ctx context.Context, userID int) (*models.User, error) {
 	user, err := s.repo.FindByID(ctx, userID)
 	if err != nil {
@@ -205,10 +207,6 @@ func (s *AuthService) GetUserByID(ctx context.Context, userID int) (*models.User
 	return user, nil
 }
 
-// VerifyToken validates a JWT token and extracts its claims.
-//
-// It checks the token's signing method, parses it with the provided claims,
-// and ensures the token is valid.
 func (s *AuthService) VerifyToken(token string) (*Claims, error) {
 	claims := &Claims{}
 	parsedToken, err := jwt.ParseWithClaims(token, claims, func(jwtToken *jwt.Token) (interface{}, error) {
@@ -232,9 +230,6 @@ func (s *AuthService) VerifyToken(token string) (*Claims, error) {
 	return claims, nil
 }
 
-// ChangePassword updates the password for a user identified by userID.
-//
-// It hashes the new password and updates the user's record in the repository.
 func (s *AuthService) ChangePassword(ctx context.Context, userID int, newPassword string) error {
 	user, err := s.repo.FindByID(ctx, userID)
 	if err != nil {
@@ -278,12 +273,10 @@ func (s *AuthService) ChangePassword(ctx context.Context, userID int, newPasswor
 	return nil
 }
 
-// VerifyPassword checks if the provided password matches the hashed password
 func (s *AuthService) VerifyPassword(hashedPassword, password string) bool {
 	return verifyPassword(hashedPassword, password)
 }
 
-// DeleteAccount deletes a user's account and all associated data
 func (s *AuthService) DeleteAccount(ctx context.Context, userID int) error {
 	s.log.Info().
 		Str("event", "account_deletion_requested").
@@ -306,17 +299,13 @@ func (s *AuthService) DeleteAccount(ctx context.Context, userID int) error {
 	return nil
 }
 
-// TokenType defines the type of JWT token
 type TokenType string
 
 const (
-	// AccessToken is a short-lived token used for authentication
-	AccessToken TokenType = "access"
-	// RefreshToken is a long-lived token used to refresh access tokens
+	AccessToken  TokenType = "access"
 	RefreshToken TokenType = "refresh"
 )
 
-// GenerateToken creates a JWT token for the given user with the specified token type and expiration duration.
 func GenerateToken(user *models.User, cfg *config.Settings, tokenType TokenType, expiry time.Duration) (string, error) {
 	expirationTime := time.Now().UTC().Add(expiry)
 	role := user.Role.String()
@@ -338,12 +327,10 @@ func GenerateToken(user *models.User, cfg *config.Settings, tokenType TokenType,
 	return token.SignedString([]byte(cfg.TokenSecret))
 }
 
-// GenerateAccessToken creates a short-lived access JWT token for the given user.
 func GenerateAccessToken(user *models.User, cfg *config.Settings) (string, error) {
 	return GenerateToken(user, cfg, AccessToken, cfg.AccessTokenExpiry)
 }
 
-// GenerateRefreshToken creates a long-lived refresh JWT token for the given user.
 func GenerateRefreshToken(user *models.User, cfg *config.Settings) (string, error) {
 	return GenerateToken(user, cfg, RefreshToken, cfg.RefreshTokenExpiry)
 }

--- a/internal/auth/services/auth_test.go
+++ b/internal/auth/services/auth_test.go
@@ -134,7 +134,7 @@ func TestLogin(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		accessToken, refreshToken, err := authService.Login(ctx, "testuser", "password123")
+		accessToken, refreshToken, _, err := authService.Login(ctx, "testuser", "password123")
 
 		require.NoError(t, err)
 		require.NotEmpty(t, accessToken)
@@ -161,13 +161,13 @@ func TestLogin(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		accessToken1, refreshToken1, err1 := authService.Login(ctx, "nonexistent", "password123")
+		accessToken1, refreshToken1, _, err1 := authService.Login(ctx, "nonexistent", "password123")
 		require.Error(t, err1)
 		require.Equal(t, models.ErrInvalidCredentials, err1)
 		require.Empty(t, accessToken1)
 		require.Empty(t, refreshToken1)
 
-		accessToken2, refreshToken2, err2 := authService.Login(ctx, "testuser", "wrongpassword")
+		accessToken2, refreshToken2, _, err2 := authService.Login(ctx, "testuser", "wrongpassword")
 		require.Error(t, err2)
 		require.Equal(t, models.ErrInvalidCredentials, err2)
 		require.Empty(t, accessToken2)
@@ -302,7 +302,7 @@ func TestRefreshAccessToken(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		newAccessToken, err := authService.RefreshAccessToken(ctx, refreshToken)
+		newAccessToken, _, _, err := authService.RefreshAccessToken(ctx, refreshToken)
 
 		require.NoError(t, err)
 		require.NotEmpty(t, newAccessToken)
@@ -322,7 +322,7 @@ func TestRefreshAccessToken(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		newAccessToken, err := authService.RefreshAccessToken(ctx, "invalid.refresh.token")
+		newAccessToken, _, _, err := authService.RefreshAccessToken(ctx, "invalid.refresh.token")
 
 		require.Error(t, err)
 		require.Equal(t, models.ErrInvalidToken, err)
@@ -345,7 +345,7 @@ func TestRefreshAccessToken(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		newAccessToken, err := authService.RefreshAccessToken(ctx, accessToken)
+		newAccessToken, _, _, err := authService.RefreshAccessToken(ctx, accessToken)
 
 		require.Error(t, err)
 		require.Equal(t, models.ErrInvalidToken, err)
@@ -370,7 +370,7 @@ func TestRefreshAccessToken(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		newAccessToken, err := authService.RefreshAccessToken(ctx, refreshToken)
+		newAccessToken, _, _, err := authService.RefreshAccessToken(ctx, refreshToken)
 
 		require.Error(t, err)
 		require.Equal(t, models.ErrInvalidToken, err)
@@ -397,7 +397,7 @@ func TestRefreshAccessToken(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		newAccessToken, err := authService.RefreshAccessToken(ctx, refreshToken)
+		newAccessToken, _, _, err := authService.RefreshAccessToken(ctx, refreshToken)
 
 		require.Error(t, err)
 		require.Equal(t, models.ErrInvalidToken, err)
@@ -498,7 +498,7 @@ func TestLoginEdgeCases(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		accessToken, refreshToken, err := authService.Login(ctx, "oauth@example.com", "anypassword")
+		accessToken, refreshToken, _, err := authService.Login(ctx, "oauth@example.com", "anypassword")
 
 		require.Error(t, err)
 		require.Equal(t, models.ErrInvalidCredentials, err)
@@ -518,7 +518,7 @@ func TestLoginEdgeCases(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		accessToken, refreshToken, err := authService.Login(ctx, "testuser", "password123")
+		accessToken, refreshToken, _, err := authService.Login(ctx, "testuser", "password123")
 
 		require.Error(t, err)
 		require.Equal(t, models.ErrInvalidCredentials, err)
@@ -682,7 +682,7 @@ func TestRefreshAccessTokenErrorScenarios(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		newAccessToken, err := authService.RefreshAccessToken(ctx, refreshToken)
+		newAccessToken, _, _, err := authService.RefreshAccessToken(ctx, refreshToken)
 
 		require.Error(t, err)
 		require.Equal(t, models.ErrInvalidToken, err)

--- a/internal/auth/services/token_test.go
+++ b/internal/auth/services/token_test.go
@@ -87,7 +87,7 @@ func TestTokenTypes(t *testing.T) {
 
 		authService := NewAuthService(mockRepo, cfg)
 
-		accessToken, refreshToken, err := authService.Login(ctx, "testuser", "password123")
+		accessToken, refreshToken, _, err := authService.Login(ctx, "testuser", "password123")
 		require.NoError(t, err)
 		require.NotEmpty(t, accessToken)
 		require.NotEmpty(t, refreshToken)


### PR DESCRIPTION
## 🚀 What's this about?

This PR improves the authentication API by adding token expiration tracking and a new verification endpoint, while removing the OAuth integration from API routes.

**Key Changes:**

- Added `expires_at` Unix timestamp to login and refresh token API responses
- Implemented new `GET /api/auth/verify` endpoint for token validation
- Enabled refresh token rotation for improved security
- Removed OAuth `/api/auth/google` endpoint from API routes (service layer preserved)

## 💡 Why this matters

The browser extension hardcoded token expiration times (1 hour) because the API wasn't providing this information. This led to:

- Premature token refreshes or unexpected 401 errors
- Poor user experience with unnecessary re-authentication
- Security concerns with clients guessing token validity

Additionally, OAuth support was being bypassed entirely in the browser extension, making the API endpoint unnecessary overhead.

## ✅ How was this tested?

- [x] Tested locally
- [x] All tests pass
- [x] Manually verified the change works as expected
