### PR TITLE
fix: add production hardening with timeouts, tracing, and panic recovery

### DIFF
--- a/internal/auth/repository/repository.go
+++ b/internal/auth/repository/repository.go
@@ -74,12 +74,12 @@ func (r *SQLiteUserRepository) CreateUser(ctx context.Context, username, passwor
 	if err != nil {
 		return nil, models.WrapError(models.ErrUserCreationFailed, err)
 	}
+	defer tx.Rollback() // No-op if commit succeeds
 
 	// Create user
 	query := "INSERT INTO users (username, password, role) VALUES (?, ?, ?)"
 	result, err := tx.ExecContext(ctx, query, username, password, roleValue)
 	if err != nil {
-		tx.Rollback()
 		if err.Error() == "UNIQUE constraint failed: users.username" {
 			existingUser, findErr := r.FindByUsername(ctx, username)
 			if findErr == nil {
@@ -92,7 +92,6 @@ func (r *SQLiteUserRepository) CreateUser(ctx context.Context, username, passwor
 
 	id, err := result.LastInsertId()
 	if err != nil {
-		tx.Rollback()
 		return nil, models.WrapError(models.ErrUserCreationFailed, err)
 	}
 

--- a/internal/cache/badger_cache.go
+++ b/internal/cache/badger_cache.go
@@ -19,7 +19,9 @@ var (
 
 // BadgerCache implements Cache interface using Badger v4
 type BadgerCache struct {
-	db *badger.DB
+	db     *badger.DB
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func NewBadgerCache(path string, maxMemoryMB int) (*BadgerCache, error) {
@@ -44,21 +46,38 @@ func NewBadgerCache(path string, maxMemoryMB int) (*BadgerCache, error) {
 		return nil, fmt.Errorf("failed to open badger cache: %w", err)
 	}
 
-	bc := &BadgerCache{db: db}
+	ctx, cancel := context.WithCancel(context.Background())
+	bc := &BadgerCache{
+		db:     db,
+		ctx:    ctx,
+		cancel: cancel,
+	}
 
-	go bc.runGC()
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().Interface("panic", r).Msg("Cache GC panic recovered")
+			}
+		}()
+		bc.runGC(ctx)
+	}()
 
 	return bc, nil
 }
 
-func (c *BadgerCache) runGC() {
+func (c *BadgerCache) runGC(ctx context.Context) {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		err := c.db.RunValueLogGC(0.5)
-		if err != nil && err != badger.ErrNoRewrite {
-			log.Warn().Err(err).Msg("Cache GC error")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			err := c.db.RunValueLogGC(0.5)
+			if err != nil && err != badger.ErrNoRewrite {
+				log.Warn().Err(err).Msg("Cache GC error")
+			}
 		}
 	}
 }
@@ -199,6 +218,7 @@ func (c *BadgerCache) Close() error {
 		return nil
 	}
 
+	c.cancel()
 	return c.db.Close()
 }
 

--- a/internal/common/utils/goroutine.go
+++ b/internal/common/utils/goroutine.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"runtime/debug"
+
+	"github.com/rs/zerolog/log"
+)
+
+// SafeGo executes a function in a goroutine with panic recovery
+func SafeGo(fn func()) {
+	if fn == nil {
+		log.Error().Msg("SafeGo called with nil function")
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().
+					Interface("panic", r).
+					Str("stack", string(debug.Stack())).
+					Msg("Panic recovered in goroutine")
+			}
+		}()
+		fn()
+	}()
+}
+
+// SafeGoWithName executes a function in a goroutine with panic recovery and a name for logging
+func SafeGoWithName(name string, fn func()) {
+	if fn == nil {
+		log.Error().Str("goroutine", name).Msg("SafeGoWithName called with nil function")
+		return
+	}
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().
+					Str("goroutine", name).
+					Interface("panic", r).
+					Str("stack", string(debug.Stack())).
+					Msg("Panic recovered in goroutine")
+			}
+		}()
+		fn()
+	}()
+}

--- a/internal/common/utils/goroutine_test.go
+++ b/internal/common/utils/goroutine_test.go
@@ -1,0 +1,194 @@
+package utils
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSafeGo(t *testing.T) {
+	t.Run("executes_function_successfully", func(t *testing.T) {
+		executed := make(chan bool, 1)
+
+		SafeGo(func() {
+			executed <- true
+		})
+
+		select {
+		case <-executed:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Function was not executed")
+		}
+	})
+
+	t.Run("recovers_from_panic", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldLogger := log.Logger
+		log.Logger = zerolog.New(&buf)
+		defer func() { log.Logger = oldLogger }()
+
+		done := make(chan bool, 1)
+
+		SafeGo(func() {
+			defer func() { done <- true }()
+			panic("test panic")
+		})
+
+		select {
+		case <-done:
+			time.Sleep(10 * time.Millisecond)
+			logOutput := buf.String()
+			assert.Contains(t, logOutput, "Panic recovered in goroutine")
+			assert.Contains(t, logOutput, "test panic")
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Function did not complete")
+		}
+	})
+
+	t.Run("handles_nil_function", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldLogger := log.Logger
+		log.Logger = zerolog.New(&buf)
+		defer func() { log.Logger = oldLogger }()
+
+		SafeGo(nil)
+		time.Sleep(10 * time.Millisecond)
+		logOutput := buf.String()
+		assert.Contains(t, logOutput, "SafeGo called with nil function")
+	})
+
+	t.Run("concurrent_execution", func(t *testing.T) {
+		var wg sync.WaitGroup
+		counter := 0
+		var mu sync.Mutex
+
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			SafeGo(func() {
+				defer wg.Done()
+				mu.Lock()
+				counter++
+				mu.Unlock()
+			})
+		}
+
+		wg.Wait()
+		assert.Equal(t, 10, counter)
+	})
+}
+
+func TestSafeGoWithName(t *testing.T) {
+	t.Run("executes_function_with_name", func(t *testing.T) {
+		executed := make(chan bool, 1)
+
+		SafeGoWithName("test-goroutine", func() {
+			executed <- true
+		})
+
+		select {
+		case <-executed:
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Function was not executed")
+		}
+	})
+
+	t.Run("logs_name_on_panic", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldLogger := log.Logger
+		log.Logger = zerolog.New(&buf)
+		defer func() { log.Logger = oldLogger }()
+
+		done := make(chan bool, 1)
+
+		SafeGoWithName("named-routine", func() {
+			defer func() { done <- true }()
+			panic("named panic")
+		})
+
+		select {
+		case <-done:
+			time.Sleep(10 * time.Millisecond)
+			logOutput := buf.String()
+			assert.Contains(t, logOutput, "named-routine")
+			assert.Contains(t, logOutput, "named panic")
+			assert.Contains(t, logOutput, "Panic recovered in goroutine")
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Function did not complete")
+		}
+	})
+
+	t.Run("handles_nil_function_with_name", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldLogger := log.Logger
+		log.Logger = zerolog.New(&buf)
+		defer func() { log.Logger = oldLogger }()
+
+		SafeGoWithName("nil-test", nil)
+
+		time.Sleep(10 * time.Millisecond)
+		logOutput := buf.String()
+		assert.Contains(t, logOutput, "SafeGoWithName called with nil function")
+		assert.Contains(t, logOutput, "nil-test")
+	})
+
+	t.Run("multiple_named_goroutines", func(t *testing.T) {
+		var wg sync.WaitGroup
+		results := make(map[string]bool)
+		var mu sync.Mutex
+
+		names := []string{"worker-1", "worker-2", "worker-3"}
+
+		for _, name := range names {
+			wg.Add(1)
+			localName := name
+			SafeGoWithName(localName, func() {
+				defer wg.Done()
+				mu.Lock()
+				results[localName] = true
+				mu.Unlock()
+			})
+		}
+
+		wg.Wait()
+		assert.Len(t, results, 3)
+		for _, name := range names {
+			assert.True(t, results[name])
+		}
+	})
+}
+
+func TestPanicRecoveryStackTrace(t *testing.T) {
+	t.Run("includes_stack_trace_in_log", func(t *testing.T) {
+		var buf bytes.Buffer
+		oldLogger := log.Logger
+		log.Logger = zerolog.New(&buf)
+		defer func() { log.Logger = oldLogger }()
+
+		done := make(chan bool, 1)
+
+		SafeGo(func() {
+			defer func() { done <- true }()
+			causePanic()
+		})
+
+		select {
+		case <-done:
+			time.Sleep(10 * time.Millisecond)
+			logOutput := buf.String()
+			assert.True(t, strings.Contains(logOutput, "goroutine") || strings.Contains(logOutput, "stack"))
+			assert.Contains(t, logOutput, "causePanic")
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Function did not complete")
+		}
+	})
+}
+
+func causePanic() {
+	panic("intentional panic for testing")
+}

--- a/internal/middleware/requestid.go
+++ b/internal/middleware/requestid.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+const (
+	RequestIDHeader = "X-Request-ID"
+	RequestIDKey    = "request_id"
+)
+
+// RequestID middleware generates or extracts a request ID for tracing
+func RequestID() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		requestID := c.Request.Header.Get(RequestIDHeader)
+		if requestID == "" {
+			requestID = uuid.New().String()
+		}
+
+		c.Set(RequestIDKey, requestID)
+		c.Writer.Header().Set(RequestIDHeader, requestID)
+
+		log.Info().
+			Str("request_id", requestID).
+			Str("method", c.Request.Method).
+			Str("path", c.Request.URL.Path).
+			Str("client_ip", c.ClientIP()).
+			Msg("Request started")
+
+		c.Next()
+
+		log.Info().
+			Str("request_id", requestID).
+			Int("status", c.Writer.Status()).
+			Str("method", c.Request.Method).
+			Str("path", c.Request.URL.Path).
+			Msg("Request completed")
+	}
+}
+
+// GetRequestID extracts the request ID from the context
+func GetRequestID(c *gin.Context) string {
+	if requestID, exists := c.Get(RequestIDKey); exists {
+		if id, ok := requestID.(string); ok {
+			return id
+		}
+	}
+	return ""
+}
+
+// WithRequestID adds request ID to logger context
+func WithRequestID(c *gin.Context) *zerolog.Logger {
+	requestID := GetRequestID(c)
+	if requestID != "" {
+		logger := log.With().Str("request_id", requestID).Logger()
+		return &logger
+	}
+	logger := log.Logger
+	return &logger
+}

--- a/internal/middleware/requestid_test.go
+++ b/internal/middleware/requestid_test.go
@@ -1,0 +1,127 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("generates_request_id_when_missing", func(t *testing.T) {
+		router := gin.New()
+		router.Use(RequestID())
+
+		var capturedID string
+		router.GET("/test", func(c *gin.Context) {
+			capturedID = GetRequestID(c)
+			c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		assert.NotEmpty(t, capturedID)
+		assert.Equal(t, capturedID, w.Header().Get(RequestIDHeader))
+	})
+
+	t.Run("uses_existing_request_id_from_header", func(t *testing.T) {
+		router := gin.New()
+		router.Use(RequestID())
+
+		expectedID := "test-request-id-123"
+		var capturedID string
+		router.GET("/test", func(c *gin.Context) {
+			capturedID = GetRequestID(c)
+			c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		req.Header.Set(RequestIDHeader, expectedID)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, expectedID, capturedID)
+		assert.Equal(t, expectedID, w.Header().Get(RequestIDHeader))
+	})
+
+	t.Run("request_id_available_in_context", func(t *testing.T) {
+		router := gin.New()
+		router.Use(RequestID())
+
+		router.GET("/test", func(c *gin.Context) {
+			id, exists := c.Get(RequestIDKey)
+			assert.True(t, exists)
+			assert.NotEmpty(t, id)
+			c.JSON(http.StatusOK, gin.H{"request_id": id})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
+func TestGetRequestID(t *testing.T) {
+	t.Run("returns_empty_string_when_not_set", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+
+		id := GetRequestID(c)
+		assert.Empty(t, id)
+	})
+
+	t.Run("returns_request_id_when_set", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+
+		expectedID := "test-id-456"
+		c.Set(RequestIDKey, expectedID)
+
+		id := GetRequestID(c)
+		assert.Equal(t, expectedID, id)
+	})
+
+	t.Run("handles_wrong_type_in_context", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+
+		c.Set(RequestIDKey, 12345)
+
+		id := GetRequestID(c)
+		assert.Empty(t, id)
+	})
+}
+
+func TestWithRequestID(t *testing.T) {
+	t.Run("returns_logger_with_request_id", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+
+		expectedID := "test-logger-id"
+		c.Set(RequestIDKey, expectedID)
+
+		logger := WithRequestID(c)
+		assert.NotNil(t, logger)
+	})
+
+	t.Run("returns_logger_without_request_id_when_missing", func(t *testing.T) {
+		gin.SetMode(gin.TestMode)
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+
+		logger := WithRequestID(c)
+		assert.NotNil(t, logger)
+	})
+}

--- a/internal/middleware/timeout.go
+++ b/internal/middleware/timeout.go
@@ -1,0 +1,26 @@
+package middleware
+
+import (
+	"context"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequestTimeout creates a middleware that adds a timeout context to requests
+// Note: This sets a timeout context but doesn't forcefully stop handler execution.
+// Handlers should check context.Done() to respect the timeout.
+func RequestTimeout(timeout time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
+		defer cancel()
+
+		c.Request = c.Request.WithContext(ctx)
+		c.Next()
+	}
+}
+
+// DatabaseTimeout wraps a context with a specific timeout for database operations
+func DatabaseTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, timeout)
+}

--- a/internal/middleware/timeout_test.go
+++ b/internal/middleware/timeout_test.go
@@ -1,0 +1,93 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("completes_before_timeout", func(t *testing.T) {
+		router := gin.New()
+		router.Use(RequestTimeout(100 * time.Millisecond))
+		router.GET("/test", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), "ok")
+	})
+
+	t.Run("context_timeout_is_set", func(t *testing.T) {
+		router := gin.New()
+		router.Use(RequestTimeout(50 * time.Millisecond))
+
+		var ctxDeadline time.Time
+		router.GET("/test", func(c *gin.Context) {
+			deadline, ok := c.Request.Context().Deadline()
+			assert.True(t, ok, "context should have deadline")
+			ctxDeadline = deadline
+			c.JSON(http.StatusOK, gin.H{"status": "ok"})
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.False(t, ctxDeadline.IsZero())
+	})
+
+	t.Run("handlers_can_check_context_cancellation", func(t *testing.T) {
+		router := gin.New()
+		router.Use(RequestTimeout(50 * time.Millisecond))
+
+		router.GET("/test", func(c *gin.Context) {
+			select {
+			case <-time.After(100 * time.Millisecond):
+				c.JSON(http.StatusOK, gin.H{"status": "should_not_reach"})
+			case <-c.Request.Context().Done():
+				return
+			}
+		})
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest("GET", "/test", nil)
+		router.ServeHTTP(w, req)
+
+		time.Sleep(60 * time.Millisecond)
+	})
+}
+
+func TestDatabaseTimeout(t *testing.T) {
+	t.Run("creates_timeout_context", func(t *testing.T) {
+		ctx := context.Background()
+		timeoutCtx, cancel := DatabaseTimeout(ctx, 100*time.Millisecond)
+		defer cancel()
+
+		deadline, ok := timeoutCtx.Deadline()
+		assert.True(t, ok, "context should have deadline")
+		assert.WithinDuration(t, time.Now().Add(100*time.Millisecond), deadline, 10*time.Millisecond)
+	})
+
+	t.Run("context_cancels_after_timeout", func(t *testing.T) {
+		ctx := context.Background()
+		timeoutCtx, cancel := DatabaseTimeout(ctx, 50*time.Millisecond)
+		defer cancel()
+
+		time.Sleep(60 * time.Millisecond)
+		assert.Error(t, timeoutCtx.Err())
+		assert.Equal(t, context.DeadlineExceeded, timeoutCtx.Err())
+	})
+}

--- a/internal/vega/app.go
+++ b/internal/vega/app.go
@@ -112,13 +112,23 @@ func (a *App) Run() error {
 	}
 
 	a.server = &http.Server{
-		Addr:    a.config.ServerPort,
-		Handler: a.router,
+		Addr:              a.config.ServerPort,
+		Handler:           a.router,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	signal.Notify(a.done, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error().Interface("panic", r).Msg("Server goroutine panic recovered")
+			}
+		}()
+
 		log.Info().Str("port", a.config.ServerPort).Msg("Starting server")
 
 		if !a.config.IsCloudMode {

--- a/internal/vega/routes.go
+++ b/internal/vega/routes.go
@@ -3,6 +3,7 @@ package vega
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/benidevo/vega/internal/ai"
 	authapi "github.com/benidevo/vega/internal/api/auth"
@@ -13,6 +14,7 @@ import (
 	"github.com/benidevo/vega/internal/documents"
 	"github.com/benidevo/vega/internal/home"
 	"github.com/benidevo/vega/internal/job"
+	localmiddleware "github.com/benidevo/vega/internal/middleware"
 	"github.com/benidevo/vega/internal/pages"
 	"github.com/benidevo/vega/internal/quota"
 	"github.com/benidevo/vega/internal/settings"
@@ -22,7 +24,9 @@ import (
 
 // SetupRoutes configures all application routes and middleware
 func SetupRoutes(a *App) {
+	a.router.Use(localmiddleware.RequestID())
 	a.router.Use(globalErrorHandler(a.renderer))
+	a.router.Use(localmiddleware.RequestTimeout(30 * time.Second))
 
 	if a.config.EnableSecurityHeaders {
 		a.router.Use(middleware.SecurityHeaders())


### PR DESCRIPTION
## 🚀 What's this about?

This PR implements critical production hardening measures to prevent resource exhaustion, improve observability, and ensure graceful failure handling. It addresses 6 high-priority production issues that could cause server crashes, connection leaks, and make debugging nearly impossible.


## 💡 Why this matters

**Without these fixes, the production system is vulnerable to:**

**Resource Exhaustion**: A single slow client could hold connections indefinitely, eventually exhausting server resources

- Before: No timeouts configured, connections held forever
- After: 15s read/write timeout, 60s idle timeout, 5s header timeout

**Goroutine Leaks**: Cache GC goroutine never stops, accumulating over time

- Before: GC goroutine runs forever even after cache closes
- After: Proper context cancellation ensures clean shutdown

**Connection Pool Exhaustion*:  Database transactions not properly rolled back on errors

- Before: Panic or early return leaves transaction open
- After: `defer tx.Rollback()` ensures cleanup (no-op if committed)

**Debugging Blindness**:  No way to trace requests through the system

- Before: No request correlation, logs scattered without context
- After: X-Request-ID header propagated and logged throughout

**Cascading Failures**: Single panic in background worker crashes entire application

- Before: Any goroutine panic terminates process
- After: Panic recovery with logging, isolated failure domains

## ✅ How was this tested?

- [x] Tested locally
- [x] All tests pass
- [x] Manually verified the change works as expected