### PR TITLE
feat: add active jobs filter with exclude statuses

### DIFF
--- a/internal/job/handlers.go
+++ b/internal/job/handlers.go
@@ -282,7 +282,7 @@ func (h *JobHandler) ListJobsPage(c *gin.Context) {
 	}
 	userID := userIDValue.(int)
 
-	statusParam := c.Query("status")
+	statusParam := c.DefaultQuery("status", "active")
 	pageParam := c.DefaultQuery("page", "1")
 	limitParam := c.DefaultQuery("limit", "12")
 	sortByParam := c.DefaultQuery("sort", "match_score")
@@ -322,7 +322,12 @@ func (h *JobHandler) ListJobsPage(c *gin.Context) {
 		SortOrder: sortOrderParam,
 	}
 
-	if statusParam != "" && statusParam != "all" {
+	if statusParam == "active" || statusParam == "" {
+		filter.ExcludeStatuses = []models.JobStatus{
+			models.REJECTED,
+			models.NOT_INTERESTED,
+		}
+	} else if statusParam != "all" {
 		jobStatus, err := models.JobStatusFromString(statusParam)
 		if err == nil {
 			filter.Status = &jobStatus
@@ -345,7 +350,7 @@ func (h *JobHandler) ListJobsPage(c *gin.Context) {
 	// Handle edge case: requested page is beyond total pages
 	if page > jobsWithPagination.Pagination.TotalPages && jobsWithPagination.Pagination.TotalPages > 0 {
 		redirectURL := "?page=" + strconv.Itoa(jobsWithPagination.Pagination.TotalPages)
-		if statusParam != "" && statusParam != "all" {
+		if statusParam != "" {
 			redirectURL += "&status=" + statusParam
 		}
 

--- a/internal/job/models/job_model.go
+++ b/internal/job/models/job_model.go
@@ -249,14 +249,15 @@ func (j *Job) GetMatchStatus() string {
 
 // JobFilter defines filters for querying jobs
 type JobFilter struct {
-	CompanyID *int
-	Status    *JobStatus
-	JobType   *JobType
-	Matched   *bool
-	Limit     int
-	Offset    int
-	SortBy    string // "match_score", "updated_at", etc.
-	SortOrder string // "asc" or "desc"
+	CompanyID       *int
+	Status          *JobStatus
+	ExcludeStatuses []JobStatus
+	JobType         *JobType
+	Matched         *bool
+	Limit           int
+	Offset          int
+	SortBy          string
+	SortOrder       string
 }
 
 type JobStats struct {

--- a/internal/job/repository/job_repository.go
+++ b/internal/job/repository/job_repository.go
@@ -507,6 +507,15 @@ func (r *SQLiteJobRepository) GetAll(ctx context.Context, userID int, filter mod
 		args = append(args, int(*filter.Status))
 	}
 
+	if len(filter.ExcludeStatuses) > 0 {
+		placeholders := make([]string, len(filter.ExcludeStatuses))
+		for i, status := range filter.ExcludeStatuses {
+			placeholders[i] = "?"
+			args = append(args, int(status))
+		}
+		conditions = append(conditions, "j.status NOT IN ("+strings.Join(placeholders, ",")+")")
+	}
+
 	if filter.JobType != nil {
 		conditions = append(conditions, "j.job_type = ?")
 		args = append(args, int(*filter.JobType))
@@ -790,6 +799,15 @@ func (r *SQLiteJobRepository) GetCount(ctx context.Context, userID int, filter m
 	if filter.Status != nil {
 		conditions = append(conditions, "j.status = ?")
 		args = append(args, int(*filter.Status))
+	}
+
+	if len(filter.ExcludeStatuses) > 0 {
+		placeholders := make([]string, len(filter.ExcludeStatuses))
+		for i, status := range filter.ExcludeStatuses {
+			placeholders[i] = "?"
+			args = append(args, int(status))
+		}
+		conditions = append(conditions, "j.status NOT IN ("+strings.Join(placeholders, ",")+")")
 	}
 
 	if filter.JobType != nil {

--- a/internal/job/repository/job_repository_test.go
+++ b/internal/job/repository/job_repository_test.go
@@ -509,6 +509,44 @@ func TestSQLiteJobRepository_GetAll(t *testing.T) {
 
 		require.NoError(t, err)
 	})
+
+	t.Run("exclude statuses", func(t *testing.T) {
+		now := time.Now()
+
+		rows := sqlmock.NewRows([]string{
+			"j.id", "j.title", "j.description", "j.location", "j.job_type",
+			"j.source_url", "j.required_skills",
+			"j.application_url", "j.company_id", "j.status", "j.match_score",
+			"j.notes", "j.created_at", "j.updated_at", "j.user_id", "j.first_analyzed_at",
+			"c.name", "c.created_at", "c.updated_at",
+		}).AddRow(
+			1, "Software Engineer", "Active job", "Remote", int(models.FULL_TIME),
+			"https://example.com", `["Go"]`,
+			"https://apply.example.com", 1, int(models.INTERESTED), 85,
+			"Good job", now.Add(-48*time.Hour), now, testUserID, nil,
+			"Tech Corp", now, now,
+		).AddRow(
+			2, "Backend Engineer", "Another active job", "Remote", int(models.FULL_TIME),
+			"https://example.com", `["Python"]`,
+			"https://apply.example.com", 1, int(models.APPLIED), 90,
+			"Great job", now.Add(-24*time.Hour), now, testUserID, nil,
+			"Tech Corp", now, now,
+		)
+
+		mock.ExpectQuery("SELECT.*FROM jobs.*WHERE.*user_id.*NOT IN.*ORDER BY").
+			WithArgs(testUserID, int(models.REJECTED), int(models.NOT_INTERESTED)).
+			WillReturnRows(rows)
+
+		filter := models.JobFilter{
+			ExcludeStatuses: []models.JobStatus{models.REJECTED, models.NOT_INTERESTED},
+		}
+		jobs, err := repo.GetAll(context.Background(), testUserID, filter)
+
+		require.NoError(t, err)
+		require.Len(t, jobs, 2)
+		assert.Equal(t, models.INTERESTED, jobs[0].Status)
+		assert.Equal(t, models.APPLIED, jobs[1].Status)
+	})
 }
 
 func TestGetStatsByUserID(t *testing.T) {

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -33,7 +33,8 @@
           name="status"
           aria-label="Filter jobs by status"
         >
-          <option value="all" {{if or (eq .statusFilter "") (eq .statusFilter "all")}}selected{{end}}>All Jobs</option>
+          <option value="active" {{if or (eq .statusFilter "") (eq .statusFilter "active")}}selected{{end}}>Active Jobs</option>
+          <option value="all" {{if eq .statusFilter "all"}}selected{{end}}>All Jobs</option>
           <option value="interested" {{if eq .statusFilter "interested"}}selected{{end}}>Interested</option>
           <option value="applied" {{if eq .statusFilter "applied"}}selected{{end}}>Applied</option>
           <option value="interviewing" {{if eq .statusFilter "interviewing"}}selected{{end}}>Interviewing</option>
@@ -74,10 +75,10 @@
     </div>
   </div>
 
-  <div id="jobs-container" class="flex-1 flex flex-col relative" aria-live="polite" aria-busy="false" 
-       hx-get="/jobs{{if or .statusFilter .sortBy}}?{{if .statusFilter}}status={{.statusFilter}}{{end}}{{if and .statusFilter .sortBy}}&{{end}}{{if .sortBy}}sort={{.sortBy}}&order={{.sortOrder}}{{end}}{{end}}" 
-       hx-trigger="load" 
-       hx-swap="innerHTML" 
+  <div id="jobs-container" class="flex-1 flex flex-col relative" aria-live="polite" aria-busy="false"
+       hx-get="/jobs{{if or .statusFilter .sortBy}}?{{if .statusFilter}}status={{.statusFilter}}{{end}}{{if and .statusFilter .sortBy}}&{{end}}{{if .sortBy}}sort={{.sortBy}}&order={{.sortOrder}}{{end}}{{end}}"
+       hx-trigger="load"
+       hx-swap="innerHTML"
        _="on htmx:beforeRequest set @aria-busy to 'true' then on htmx:afterSwap set @aria-busy to 'false'">
     <div class="px-4 md:px-0">
       <div class="animate-pulse">

--- a/templates/partials/jobs-container.html
+++ b/templates/partials/jobs-container.html
@@ -38,11 +38,31 @@
         <svg class="mx-auto h-12 w-12 text-gray-400 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
         </svg>
-        <h3 class="text-lg font-medium text-white mb-2">No jobs yet</h3>
-        <p class="text-gray-400 mb-4">Start tracking your job applications</p>
-        <a href="/jobs/new" class="inline-flex items-center px-5 py-3 sm:px-4 sm:py-2 bg-primary hover:bg-primary-dark text-white rounded-md min-h-[48px] sm:min-h-0">
-          Add Job
-        </a>
+        {{if or (eq .statusFilter "active") (eq .statusFilter "")}}
+          <h3 class="text-lg font-medium text-white mb-2">No active jobs</h3>
+          <p class="text-gray-400 mb-4">
+            All your tracked jobs are rejected or marked as not interested.
+          </p>
+          <div class="flex flex-col sm:flex-row gap-3 justify-center">
+            <a href="/jobs/new" class="inline-flex items-center px-5 py-3 sm:px-4 sm:py-2 bg-primary hover:bg-primary-dark text-white rounded-md min-h-[48px] sm:min-h-0">
+              Add New Job
+            </a>
+            <button
+              hx-get="/jobs?status=all"
+              hx-target="#jobs-container"
+              hx-push-url="true"
+              _="on click set #status-filter.value to 'all'"
+              class="inline-flex items-center px-5 py-3 sm:px-4 sm:py-2 bg-slate-700 hover:bg-slate-600 text-white rounded-md min-h-[48px] sm:min-h-0">
+              View All Jobs
+            </button>
+          </div>
+        {{else}}
+          <h3 class="text-lg font-medium text-white mb-2">No jobs yet</h3>
+          <p class="text-gray-400 mb-4">Start tracking your job applications</p>
+          <a href="/jobs/new" class="inline-flex items-center px-5 py-3 sm:px-4 sm:py-2 bg-primary hover:bg-primary-dark text-white rounded-md min-h-[48px] sm:min-h-0">
+            Add Job
+          </a>
+        {{end}}
       </div>
   {{end}}
 </div>


### PR DESCRIPTION
## 🚀 What's this about?

This PR adds an "Active Jobs" filter as the default view for the job dashboard, which automatically excludes rejected and not interested jobs. Users can still view all jobs by selecting the "All Jobs" option from the dropdown.

**Key changes:**

- Default job listing now shows only "active" jobs (excludes REJECTED and NOT_INTERESTED statuses)
- New `ExcludeStatuses` field in `JobFilter` model for negative filtering
- SQL repository implements `NOT IN` clause for status exclusion
- Context-aware empty state with "View All Jobs" button when no active jobs exist
- Dropdown filter state syncs when switching views via button click

## 💡 Why this matters

**Problem:** Users were overwhelmed seeing all jobs including rejected ones by default, making it harder to focus on actionable opportunities.

**Solution:** By defaulting to "active" jobs, users immediately see only the jobs they care about:

- Jobs they're interested in
- Jobs they've applied to
- Jobs they're interviewing for
- Jobs with offers

This reduces cognitive load and improves the job search workflow while still allowing access to rejected/not interested jobs via the "All Jobs" filter.

## ✅ How was this tested?

- [x] Tested locally
- [x] All tests pass
- [x] Manually verified the change works as expected
- [x] Added test coverage for `ExcludeStatuses` filter in repository layer

