### PR TITLE
fix: restore formatting on browser back button and prevent memory leaks

### DIFF
--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -213,8 +213,10 @@
     let hasUnsavedChanges = false;
 
     function trackFormChanges() {
-      const forms = document.querySelectorAll('form');
+      const forms = document.querySelectorAll('form:not([data-changes-tracked])');
       forms.forEach(form => {
+        form.setAttribute('data-changes-tracked', 'true');
+
         const formData = new FormData(form);
         const originalData = new Map();
 
@@ -326,6 +328,11 @@
 
     document.addEventListener('DOMContentLoaded', function() {
       if (typeof htmx !== 'undefined') {
+        document.body.addEventListener('htmx:historyRestore', function(event) {
+          formatUTCDates();
+          trackFormChanges();
+        });
+
         document.body.addEventListener('htmx:beforeSwap', function(event) {
           if (event.detail.xhr.status === 404) {
             const contentType = event.detail.xhr.getResponseHeader('content-type');


### PR DESCRIPTION
## 🚀 What's this about?

This PR fixes browser back button navigation losing page formatting and introduces memory leak prevention in form change tracking.

## ✅ How was this tested?

- [x] Tested locally
- [x] All tests pass
- [x] Manually verified the change works as expected
